### PR TITLE
🎉 Feat: 프리미어리그 5 월 경기 일정 정보 크롤링 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea
 
 # AWS User-specific
 .idea/**/aws.xml

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,intellij,java,gradle
+.idea/compiler.xml

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.seleniumhq.selenium:selenium-java:4.20.0'
+	implementation 'org.projectlombok:lombok:1.18.16'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,3 @@ dependencies {
 	implementation 'org.projectlombok:lombok:1.18.16'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}

--- a/src/main/java/KickIt/server/domain/fixture/entity/Fixture.java
+++ b/src/main/java/KickIt/server/domain/fixture/entity/Fixture.java
@@ -1,0 +1,34 @@
+package KickIt.server.domain.fixture.entity;
+
+import KickIt.server.domain.teams.EplTeams;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+// 한 경기의 정보를 담을 class Fixture
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Fixture {
+    // 경기 날짜 및 시간
+    private Date date;
+    // 경기 장소
+    private String stadium;
+    // 홈팀 이름
+    private EplTeams homeTeam;
+    // 원정팀 이름
+    private EplTeams awayTeam;
+    // 홈팀 점수
+    private Integer homeTeamScore;
+    // 원정팀 점수
+    private Integer awayteamScore;
+
+}
+
+
+
+

--- a/src/main/java/KickIt/server/domain/teams/EplTeams.java
+++ b/src/main/java/KickIt/server/domain/teams/EplTeams.java
@@ -1,0 +1,47 @@
+package KickIt.server.domain.teams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// 현재 상위 20 개 EPL 팀
+public enum EplTeams {
+    MCI("Manchester City", "맨시티"),
+    ARS("Arsenal", "아스널"),
+    LIV("Liverpool", "리버풀"),
+    AVL("Aston Villa", "애스턴 빌라"),
+    TOT("Tottenham Hotspur", "토트넘"),
+    NEW("Newcastle United", "뉴캐슬"),
+    CHE("Chelsea", "첼시"),
+    MUN("Manchester United", "맨유"),
+    WHU("West Ham United", "웨스트햄"),
+    BHA("Brighton and Hove Albion", "브라이튼"),
+    BOU("AFC Bournemouth", "본머스"),
+    CRY("Crystal Palace", "크리스탈 팰리스"),
+    WOL("Wolverhampton Wanderers", "울버햄튼"),
+    FUL("Fulham", "풀럼"),
+    EVE("Everton", "에버턴"),
+    BRE("Brentford", "브렌트포드"),
+    NFO("Nottingham Forest", "노팅엄"),
+    LUT("Luton Town", "루턴 타운"),
+    BUR("Burnley", "번리"),
+    SHU("Sheffield United", "셰필드")
+    ;
+    private final String engName;
+    private final String krName;
+
+    EplTeams(String engName, String krName){
+        this.engName = engName;
+        this.krName = krName;
+    }
+    // 한국어 이름으로 EPLTEAM 찾을 수 있도록 MAP 사용
+    private static final Map<String, EplTeams> BY_KRNAME = new HashMap<>();
+    static {
+        for(EplTeams e : values()){
+            BY_KRNAME.put(e.krName, e);
+        }
+    }
+    // 한국어 이름으로 해당 되는 EplTeam 찾아 반환
+    public static EplTeams valueOfKrName(String krName){
+        return BY_KRNAME.get(krName);
+    }
+}

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -1,0 +1,128 @@
+/* 경기 일정 정보 불러오는 웹 크롤러 FixtureCrawler */
+package KickIt.server.global.common.crawler;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.global.util.WebDriverUtil;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.util.ObjectUtils;
+
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+// 경기 일정 정보 크롤링하는 FixtureCrawler
+public class FixtureCrawler {
+    // YYYY년 MM 월의 경기 일정 정보를 가져와 Fixture 객체 리스트로 반환하는 getFixture 함수
+    List<Fixture> getFixture(String year, String month){
+        WebDriver driver = WebDriverUtil.getChromeDriver();
+        // 입력받은 연도와 월을 합쳐 page 주소 가져옴
+        // daum 스포츠 프리미어리그 경기 일정 페이지
+        String pageUrl = "https://sports.daum.net/schedule/epl?date=" + year + month;
+        // 결과로 반환할 Fixture 객체 리스트
+        List<Fixture> fixtureList = new ArrayList<>();
+
+        if(!ObjectUtils.isEmpty(driver)){
+            // 페이지 열고 타임 아웃 관련 처리
+            driver.get(pageUrl);
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+
+            // 페이지에서 불러온 경기 일정 table fixtureTable에 저장
+            List<WebElement> webElementList = driver.findElements(By.id("scheduleList"));
+            WebElement fixtureTable = webElementList.get(0);
+            // fixtureTable의 행(tr)들을 담은 list fixtureTrList
+            List<WebElement> fixtureTrList = fixtureTable.findElements(By.tagName("tr"));
+
+            // fixtureTrList의 요소마다 내부 정보 parsing해 Fixture 객체로 build해 list에 추가하는 과정
+            for(int i = 0; i < fixtureTrList.size(); i++){
+                WebElement tr = fixtureTrList.get(i);
+                String trClassName = tr.getAttribute("class");
+                // 경기가 있는 날인 경우
+                if (!trClassName.contains("tr_empty")){
+                    // 경기 연기 시 continue
+                    if(isDelayed(tr))
+                        continue;
+                    // 정상적으로 경기 진행되는 경우 fixtureList에 Fixture build해 삽입
+                    // 각 팀의 정보를 포함하는 tr을 담은 list
+                    List<WebElement> teams = getTeams(tr);
+                    // 각 팀의 이름 EplTeams 배열로 저장
+                    EplTeams[] teamNames = getTeamNames(teams);
+                    // 각 팀의 점수 배열로 저장
+                    Integer[] teamScores = getTeamScores(teams);
+                    // 한 경기의 날짜 및 시간, 경기 장소, 홈팀 이름, 원정팀 이름, 홈팀 점수, 원정팀 점수를 Fixture 객체에 build
+                    Fixture fixture = Fixture.builder()
+                            .date(getFixtureDate(tr))
+                            .stadium(getStadium(tr))
+                            .homeTeam(teamNames[0])
+                            .awayTeam(teamNames[1])
+                            .homeTeamScore(teamScores[0])
+                            .awayteamScore(teamScores[1])
+                            .build();
+                    // fixture 리스트에 삽입
+                    fixtureList.add(fixture);
+                }
+            }
+        }
+
+        driver.quit();
+        return fixtureList;
+    }
+
+    // 경기 날짜와 시간 정보를 tr에서 가져와 Date format으로 변경한 후 return 하는 함수 getFixtureDate()
+    Date getFixtureDate(WebElement row){
+        // table row에서 가져온 날짜 문자열
+        String dateStr = row.getAttribute("data-date");
+        // table row에서 가져온 시간 문자열
+        String timeStr = row.findElement(By.className("td_time")).getText().replaceAll("[^0-9:]", "");
+        String fixtureDateStr = dateStr+timeStr+":00";
+        // 가져온 날짜, 시간 문자열을 Date로 변환할 SimpleDataFormat 객체
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHH:mm:ss");
+        // 반환할 Date 객체
+        Date fixtureDate = null;
+        // 가져온 날짜, 시간 문자열을 Date format으로 변환
+        try {
+            fixtureDate = sdf.parse(fixtureDateStr);
+
+        } catch (Exception e){
+            // TODO: handle exception
+        }
+        return fixtureDate;
+    }
+
+    // 경기 장소를 반환하는 함수 getStadium
+    String getStadium(WebElement row){
+        return row.findElement(By.className("td_area")).getText();
+    }
+    // 경기 연기 여부를 반환하는 함수 isDelayed
+    boolean isDelayed(WebElement row){
+        boolean isDelayed = false;
+        if( row.findElement(By.className("td_team")).findElement(By.className("state_game")).getText().equals("연기")){
+            isDelayed = true;
+        }
+        return isDelayed;
+    }
+    // 경기 참여하는 두 팀 정보를 담은 webElement를 반환하는 함수 getTeams
+    List<WebElement> getTeams(WebElement row){
+        return row.findElement(By.className("td_team")).findElements(By.tagName("div"));
+    }
+    // 경기에 참여하는 두 팀의 이름을 담은 배열을 반환하는 함수 getTeamNames
+    // 0 번 요소가 홈팀, 1 번 요소가 원정팀
+    EplTeams[] getTeamNames(List<WebElement> row){
+        String homeTeamName = row.get(0).findElement(By.className("txt_team")).getText();
+        String awayTeamName = row.get(1).findElement(By.className("txt_team")).getText();
+        return new EplTeams[]{EplTeams.valueOfKrName(homeTeamName), EplTeams.valueOfKrName(awayTeamName)};
+    }
+    // 경기에 참여하는 두 팀의 점수를 담은 배열을 반환하는 함수 getTeamScores
+    // 0 번 요소가 홈팀, 1 번 요소가 원정팀
+    // 아직 경기 치르지 않은 경우 null로 처리
+    Integer[] getTeamScores(List<WebElement> row){
+        String homeTeamScore = row.get(0).findElement(By.className("num_score")).getText().replaceAll("[^0-9]","");
+        String awayTeamScore = row.get(1).findElement(By.className("num_score")).getText().replaceAll("[^0-9]","");
+        return new Integer[]{homeTeamScore.isEmpty()?null:Integer.parseInt(homeTeamScore), awayTeamScore.isEmpty()?null:Integer.parseInt(awayTeamScore)};
+    }
+}

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -11,7 +11,6 @@ import org.springframework.util.ObjectUtils;
 
 import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/KickIt/server/global/util/WebDriverUtil.java
+++ b/src/main/java/KickIt/server/global/util/WebDriverUtil.java
@@ -1,0 +1,63 @@
+/* 크롬 드라이버의 생성 및 설치 경로 상수 저장하는 util 클래스  */
+package KickIt.server.global.util;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.util.ObjectUtils;
+
+import java.time.Duration;
+
+public class WebDriverUtil {
+    // web driver ID
+    public static final String WEB_DRIVER_ID = "webdriver.chrome.driver";
+    // web driver의 경로
+    private static final String WEB_DRIVER_PATH = "src/main/java/KickIt/server/global/common/crawler/chromedriver.exe";
+
+    // chrome driver 생성 함수
+    public static WebDriver getChromeDriver(){
+        if (ObjectUtils.isEmpty(System.getProperty(WEB_DRIVER_ID))){
+            System.setProperty(WEB_DRIVER_ID, WEB_DRIVER_PATH);
+        }
+
+        // webDriver 옵션 설정
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+
+        chromeOptions.addArguments("--headless=new");
+        chromeOptions.addArguments("--lang=ko");
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--disable-dev-shm-usage");
+        chromeOptions.addArguments("--disable-gpu");
+        //chromeOptions.setCapability("ignoreProtectedModeSettings", true);
+
+        // option 대로의 chrome driver 생성
+        WebDriver driver = new ChromeDriver(chromeOptions);
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+
+        return driver;
+    }
+    /*
+
+    // WEB_DRIVER_PATH 상수에 크롬 드라이버 설치 경로 저장
+    @Value("{resource['driver.chrome.driver_path']}")
+    public void initDriver(String path){
+        WEB_DRIVER_PATH = path;
+    }
+
+     */
+
+    // 모든 탭 종료
+    public static void quit(WebDriver driver){
+        if(!ObjectUtils.isEmpty(driver)){
+            driver.quit();
+        }
+    }
+
+    // 현재 보고 있는 크롬 드라이버 다운로드하는 탭만 종료
+    public static void close(WebDriver driver){
+        if(!ObjectUtils.isEmpty(driver)){
+            driver.close();
+        }
+    }
+}

--- a/src/main/java/KickIt/server/global/util/WebDriverUtil.java
+++ b/src/main/java/KickIt/server/global/util/WebDriverUtil.java
@@ -4,24 +4,28 @@ package KickIt.server.global.util;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.ObjectUtils;
 
 import java.time.Duration;
 
 public class WebDriverUtil {
+    // Mac에서 실행 가능하도록 ID / 경로 삭제
     // web driver ID
-    public static final String WEB_DRIVER_ID = "webdriver.chrome.driver";
+    //public static final String WEB_DRIVER_ID = "webdriver.chrome.driver";
     // web driver의 경로
-    private static final String WEB_DRIVER_PATH = "src/main/java/KickIt/server/global/common/crawler/chromedriver.exe";
+    //private static final String WEB_DRIVER_PATH = "src/main/java/KickIt/server/global/common/crawler/chromedriver.exe";
 
     // chrome driver 생성 함수
     public static WebDriver getChromeDriver(){
+        // Mac에서 실행 가능하도록 ID / 경로 삭제
+        /*
         if (ObjectUtils.isEmpty(System.getProperty(WEB_DRIVER_ID))){
             System.setProperty(WEB_DRIVER_ID, WEB_DRIVER_PATH);
         }
+         */
 
         // webDriver 옵션 설정
-
         ChromeOptions chromeOptions = new ChromeOptions();
 
         chromeOptions.addArguments("--headless=new");
@@ -37,8 +41,9 @@ public class WebDriverUtil {
 
         return driver;
     }
-    /*
 
+    /*
+    // Mac에서 실행 가능하도록 ID / 경로 삭제
     // WEB_DRIVER_PATH 상수에 크롬 드라이버 설치 경로 저장
     @Value("{resource['driver.chrome.driver_path']}")
     public void initDriver(String path){
@@ -46,6 +51,7 @@ public class WebDriverUtil {
     }
 
      */
+
 
     // 모든 탭 종료
     public static void quit(WebDriver driver){


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #1
<br>
closed jira #SF-37

## ✨ 변경 사항 및 이유
- windows 용 chromeDriver 추가
- gitignore에 idea 파일 다시 추가
- builder annotation 사용 위한 lombok dependency 추가 

- 크롤링 작업 전반에 사용할 수 있는 chromeDriver 생성하는 webDriverUtil 추가
- 한 경기의 정보(경기 날짜, 장소, 팀, 점수 등)를 저장하기 위한 Fixture 클래스 추가
- 입력한 연도와 달의 경기 목록을 크롤링해 Fixture 형태로 가져오는 FixtureCrawler 추가
- EPL 팀들 쉽게 처리하기 위한 Enum EplTeams 추가