### PR TITLE
Sf 42/feat/#6 crawling lineup crawler

### DIFF
--- a/src/main/java/KickIt/server/domain/lineup/entity/MatchLineup.java
+++ b/src/main/java/KickIt/server/domain/lineup/entity/MatchLineup.java
@@ -1,0 +1,32 @@
+package KickIt.server.domain.lineup.entity;
+
+import KickIt.server.domain.teams.EplTeams;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// 경기별 선발 라인업 정보를 담을 class MatchLineup
+public class MatchLineup {
+    // 경기 고유 id
+    private UUID id;
+    // 홈팀
+    private EplTeams homeTeam;
+    // 원정팀
+    private EplTeams awayTeam;
+    // 홈팀 포메이션
+    private String homeTeamForm;
+    // 원정팀 포메이션
+    private String awayTeamForm;
+    // 홈팀 선발 라인업
+    private TeamLineup homeTeamLineup;
+    // 원정팀 선발 라인업
+    private TeamLineup awayTeamLineup;
+
+}

--- a/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
+++ b/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
@@ -1,10 +1,13 @@
 package KickIt.server.domain.lineup.entity;
 
 import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.entity.Player;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
 
 @Getter
 @Builder
@@ -17,5 +20,9 @@ public class TeamLineup {
     // 포메이션
     private String form;
     // 선수 리스트
-    private int[] players;
+    private ArrayList<Player> players;
+    // 감독 이름
+    private String director;
+    // 후보 선수 리스트
+    private ArrayList<Player> benchPlayers;
 }

--- a/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
+++ b/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
@@ -1,0 +1,21 @@
+package KickIt.server.domain.lineup.entity;
+
+import KickIt.server.domain.teams.EplTeams;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+//각 팀별 선발 라인업을 담을 class TeamLineup
+public class TeamLineup {
+    // 팀
+    private EplTeams team;
+    // 포메이션
+    private String form;
+    // 선수 리스트
+    private int[] players;
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -22,4 +22,6 @@ public class Player {
     private int number;
     // 선수 이름
     private String name;
+    // 선수 포지션
+    private String position;
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -1,0 +1,25 @@
+package KickIt.server.domain.teams.entity;
+
+import KickIt.server.domain.teams.EplTeams;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+// 한 선수의 정보를 담을 class Player
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Player {
+    // 선수 고유 id
+    private UUID id;
+    // 선수 소속팀
+    private EplTeams team;
+    // 선수 등번호
+    private int number;
+    // 선수 이름
+    private String name;
+}

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -70,9 +70,9 @@ public class FixtureCrawler {
                     fixtureList.add(fixture);
                 }
             }
+            WebDriverUtil.close(driver);
         }
-
-        driver.quit();
+        WebDriverUtil.quit(driver);
         return fixtureList;
     }
 

--- a/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
@@ -22,14 +22,14 @@ import java.util.logging.Logger;
 public class LineupCrawler {
     MatchLineup getLineup(Fixture fixture){
         WebDriver driver = WebDriverUtil.getChromeDriver();
-        // String pageUrl = "https://sports.daum.net/" + fixture.getLineupUrl() + "?tab=lineup";
-        String pageUrl = "https://sports.daum.net/match/80074533?tab=lineup";
+        String pageUrl = "https://sports.daum.net/" + fixture.getLineupUrl() + "?tab=lineup";
+        // String pageUrl = "https://sports.daum.net/match/80074533?tab=lineup";
         MatchLineup matchLineup = new MatchLineup();
 
         if (!ObjectUtils.isEmpty(driver)) {
             // 페이지 열고 타임 아웃 관련 처리
             driver.get(pageUrl);
-            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+            driver.manage().timeouts().implicitlyWait(Duration.ofMinutes(15));
 
             // 선발 라인업 정보 전체 포함하는 WebElement
             WebElement homeElement = driver.findElement(By.className("lineup_vs1"));

--- a/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
@@ -1,0 +1,76 @@
+package KickIt.server.global.common.crawler;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.lineup.entity.MatchLineup;
+import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.entity.Player;
+import KickIt.server.global.util.WebDriverUtil;
+import ch.qos.logback.core.joran.sanity.Pair;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.util.ObjectUtils;
+
+import java.lang.reflect.Array;
+import java.time.Duration;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// 경기 선발 라인업을 크롤링하는 LineupCrawler
+public class LineupCrawler {
+    void getLineup(Fixture fixture){
+        WebDriver driver = WebDriverUtil.getChromeDriver();
+        String pageUrl = "https://sports.daum.net/" + fixture.getLineupUrl() + "?tab=lineup";
+        if (!ObjectUtils.isEmpty(driver)) {
+            // 페이지 열고 타임 아웃 관련 처리
+            driver.get(pageUrl);
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+
+            // 선발 라인업 정보 전체 포함하는 WebElement
+            WebElement homeElement = driver.findElement(By.className("lineup_vs1"));
+            WebElement awayElement = driver.findElement(By.className("lineup_vs2"));
+
+            String homeForm = homeElement.findElement(By.className("txt_lineup")).getText();
+            String awayForm = awayElement.findElement(By.className("txt_lineup")).getText();
+
+            EplTeams homeTeam = EplTeams.valueOfKrName(homeElement.findElement(By.className("tit_team")).getText());
+            EplTeams awayTeam = EplTeams.valueOfKrName(awayElement.findElement(By.className("tit_team")).getText());
+
+            List<WebElement> homePlayersElement = homeElement.findElements(By.className("txt_name"));
+            List<WebElement> awayPlayersElement = awayElement.findElements(By.className("txt_name"));
+
+            ArrayList<Player> homePlayers = new ArrayList<>();
+            ArrayList<Player> awayPlayers = new ArrayList<>();
+
+            for (int i = 0; i < 11; i++){
+                String homePlayer = homePlayersElement.get(i).getText();
+                String awayPlayer = awayPlayersElement.get(i).getText();
+                homePlayers.add(Player.builder()
+                        .id(UUID.randomUUID())
+                        .team(homeTeam)
+                        .number(Integer.parseInt(homePlayer.replaceAll("[^0-9]", "")))
+                        .name(homePlayer.replaceAll("[^가-힣]", ""))
+                        .build());
+
+                awayPlayers.add(Player.builder()
+                        .id(UUID.randomUUID())
+                        .team(awayTeam)
+                        .number(Integer.parseInt(awayPlayer.replaceAll("[^0-9]", "")))
+                        .name(awayPlayer.replaceAll("[^가-힣]", ""))
+                        .build());
+            }
+
+            Logger.getGlobal().log(Level.INFO, homeForm);
+            Logger.getGlobal().log(Level.INFO, awayForm);
+
+            for (int i = 0; i < 11; i++){
+                Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", homePlayers.get(i).getId(), homePlayers.get(i).getTeam(), homePlayers.get(i).getNumber(), homePlayers.get(i).getName()));
+            }
+            for (int i = 0; i < 11; i++){
+                Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", awayPlayers.get(i).getId(), awayPlayers.get(i).getTeam(), awayPlayers.get(i).getNumber(), awayPlayers.get(i).getName()));
+            }
+        }
+        driver.quit();
+    }
+}

--- a/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
@@ -2,26 +2,24 @@ package KickIt.server.global.common.crawler;
 
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.lineup.entity.MatchLineup;
+import KickIt.server.domain.lineup.entity.TeamLineup;
 import KickIt.server.domain.teams.EplTeams;
 import KickIt.server.domain.teams.entity.Player;
 import KickIt.server.global.util.WebDriverUtil;
-import ch.qos.logback.core.joran.sanity.Pair;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.springframework.util.ObjectUtils;
 
-import java.lang.reflect.Array;
 import java.time.Duration;
 import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 // 경기 선발 라인업을 크롤링하는 LineupCrawler
 public class LineupCrawler {
-    void getLineup(Fixture fixture){
+    MatchLineup getLineup(Fixture fixture){
         WebDriver driver = WebDriverUtil.getChromeDriver();
         String pageUrl = "https://sports.daum.net/" + fixture.getLineupUrl() + "?tab=lineup";
+        MatchLineup matchLineup = new MatchLineup();
         if (!ObjectUtils.isEmpty(driver)) {
             // 페이지 열고 타임 아웃 관련 처리
             driver.get(pageUrl);
@@ -31,46 +29,105 @@ public class LineupCrawler {
             WebElement homeElement = driver.findElement(By.className("lineup_vs1"));
             WebElement awayElement = driver.findElement(By.className("lineup_vs2"));
 
-            String homeForm = homeElement.findElement(By.className("txt_lineup")).getText();
-            String awayForm = awayElement.findElement(By.className("txt_lineup")).getText();
+            // 홈팀과 원정팀의 선발 라인업 포메이션 정보를 문자열로 크롤링
+            String homeForm = getForm(homeElement);
+            String awayForm = getForm(awayElement);
 
-            EplTeams homeTeam = EplTeams.valueOfKrName(homeElement.findElement(By.className("tit_team")).getText());
-            EplTeams awayTeam = EplTeams.valueOfKrName(awayElement.findElement(By.className("tit_team")).getText());
+            // 홈팀과 원정팀의 감독 정보를 담은 element
+            WebElement DirectorsElement = driver.findElement(By.className("substitute_coach"));
+            // 홈팀과 원정팀의 감독 정보를 문자열로 크롤링
+            String homeDirector = getDirector(DirectorsElement)[0];
+            String awayDirector = getDirector(DirectorsElement)[1];
 
-            List<WebElement> homePlayersElement = homeElement.findElements(By.className("txt_name"));
-            List<WebElement> awayPlayersElement = awayElement.findElements(By.className("txt_name"));
+            // 홈팀 선수 리스트와 원정팀 선수 리스트 정보를 크롤링해 Player 객체 List로 저장
+            ArrayList<Player> homePlayers = getPlayers(homeElement, fixture.getHomeTeam());
+            ArrayList<Player> awayPlayers = getPlayers(awayElement, fixture.getAwayTeam());
 
-            ArrayList<Player> homePlayers = new ArrayList<>();
-            ArrayList<Player> awayPlayers = new ArrayList<>();
+            // 각 팀의 후보 선수 리스트를 가져오기 위한 후보 선수 정보가 담긴 Webelement > 그 중 li 요소 찾음
+            List<WebElement> homeBenchElement = driver.findElements(By.className("list_substitute")).get(2).findElements(By.cssSelector("li"));
+            List<WebElement> awayBenchElement = driver.findElements(By.className("list_substitute")).get(3).findElements(By.cssSelector("li"));
 
-            for (int i = 0; i < 11; i++){
-                String homePlayer = homePlayersElement.get(i).getText();
-                String awayPlayer = awayPlayersElement.get(i).getText();
-                homePlayers.add(Player.builder()
-                        .id(UUID.randomUUID())
-                        .team(homeTeam)
-                        .number(Integer.parseInt(homePlayer.replaceAll("[^0-9]", "")))
-                        .name(homePlayer.replaceAll("[^가-힣]", ""))
-                        .build());
+            // 홈팀과 원정팀의 후보 선수 리스트를 크롤링해 Player 객체 List로 저장
+            ArrayList<Player> homeBenchPlayers = getBenchPlayers(homeBenchElement, fixture.getHomeTeam());
+            ArrayList<Player> awayBenchPlayers = getBenchPlayers(awayBenchElement, fixture.getAwayTeam());
 
-                awayPlayers.add(Player.builder()
-                        .id(UUID.randomUUID())
-                        .team(awayTeam)
-                        .number(Integer.parseInt(awayPlayer.replaceAll("[^0-9]", "")))
-                        .name(awayPlayer.replaceAll("[^가-힣]", ""))
-                        .build());
-            }
+            // 위에서 크롤링해 온 정보 바탕으로 홈팀 TeamLineup 클래스 객체 build
+            TeamLineup homeTeamLineup =
+                    TeamLineup.builder()
+                            .team(fixture.getHomeTeam())
+                            .form(homeForm)
+                            .players(homePlayers)
+                            .director(homeDirector)
+                            .benchPlayers(homeBenchPlayers)
+                            .build();
+            // 위에서 크롤링해 온 정보 바탕으로 원정팀 TeamLineup 클래스 객체 build
+            TeamLineup awayTeamLineup =
+                    TeamLineup.builder()
+                            .team(fixture.getAwayTeam())
+                            .form(awayForm)
+                            .players(awayPlayers)
+                            .director(awayDirector)
+                            .benchPlayers(awayBenchPlayers)
+                            .build();
 
-            Logger.getGlobal().log(Level.INFO, homeForm);
-            Logger.getGlobal().log(Level.INFO, awayForm);
-
-            for (int i = 0; i < 11; i++){
-                Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", homePlayers.get(i).getId(), homePlayers.get(i).getTeam(), homePlayers.get(i).getNumber(), homePlayers.get(i).getName()));
-            }
-            for (int i = 0; i < 11; i++){
-                Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", awayPlayers.get(i).getId(), awayPlayers.get(i).getTeam(), awayPlayers.get(i).getNumber(), awayPlayers.get(i).getName()));
-            }
+            // 위에서 만든 홈팀 / 원정팀 TeamLineup 객체들 포함해 경기의 matchLineup 객체 build
+            matchLineup =
+                    MatchLineup.builder()
+                            .id(fixture.getId())
+                            .homeTeam(fixture.getHomeTeam())
+                            .awayTeam(fixture.getAwayTeam())
+                            .homeTeamForm(homeForm)
+                            .awayTeamForm(awayForm)
+                            .homeTeamLineup(homeTeamLineup)
+                            .awayTeamLineup(awayTeamLineup)
+                            .build();
         }
         driver.quit();
+        return matchLineup;
+    }
+    // 팀별 포메이션 정보 반환하는 함수
+    String getForm(WebElement element){ return element.findElement(By.className("txt_lineup")).getText(); }
+
+    // 팀별 감독 정보 String 배열로 반환하는 함수
+    String[] getDirector(WebElement element){
+        String homeDirector = element.findElements(By.className("item_substitute")).get(0).getText();
+        String awayDirector = element.findElements(By.className("item_substitute")).get(1).getText();
+        return new String[]{homeDirector, awayDirector};
+    }
+
+    // 매개변수로 주어진 WebElement에서 선수 리스트를 가져오는 함수
+    ArrayList<Player> getPlayers(WebElement element, EplTeams teamName){
+        // 반환할 Player 객체 리스트 생성
+        ArrayList<Player> players = new ArrayList<>();
+        // 주어진 매개변수 Element에서 선수 명단이 있는 Element 찾아 가져옴
+        List<WebElement> playersElement = element.findElements(By.className("txt_name"));
+        // 각 팀 선수 인원 수만큼 선수 명단 Element에서 필요한 선수 정보 가져와 Player 객체로 build -> players list에 추가
+        for (int i = 0; i < 11; i++){
+            String playerInfo = playersElement.get(i).getText();
+            players.add(Player.builder()
+                    .id(UUID.randomUUID())
+                    .team(teamName)
+                    .number(Integer.parseInt(playerInfo.replaceAll("[^0-9]", "")))
+                    .name(playerInfo.replaceAll("[^가-힣]", ""))
+                    .build());
+        }
+        return players;
+    }
+
+    // 매개변수로 주어진 WebElement에서 후보 선수 리스트를 가져오는 함수
+    ArrayList<Player> getBenchPlayers(List<WebElement> elements, EplTeams teamName){
+        // 반환할 Player 객체 리스트 생성
+        ArrayList<Player> benchPlayers = new ArrayList<>();
+        for(int i = 0; i < elements.size(); i++) {
+            String playerNum = elements.get(i).findElement(By.className("number_g")).getText();
+            String playerName = elements.get(i).findElement(By.className("txt_name")).getText();
+            benchPlayers.add(Player.builder()
+                    .id(UUID.randomUUID())
+                    .team(teamName)
+                    .number(Integer.parseInt(playerNum.replaceAll("[^0-9]", "")))
+                    .name(playerName)
+                    .build());
+        }
+        return benchPlayers;
     }
 }

--- a/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
@@ -29,7 +29,7 @@ public class LineupCrawler {
         if (!ObjectUtils.isEmpty(driver)) {
             // 페이지 열고 타임 아웃 관련 처리
             driver.get(pageUrl);
-            driver.manage().timeouts().implicitlyWait(Duration.ofMinutes(15));
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
 
             // 선발 라인업 정보 전체 포함하는 WebElement
             WebElement homeElement = driver.findElement(By.className("lineup_vs1"));
@@ -42,7 +42,7 @@ public class LineupCrawler {
                 // => 실패 시 예외 처리
                 // 이후 getLineup 함수 자체를 5 분, 10 분 간격으로 null이 아닐 때까지 반복 실행해 보면 될 듯.
                 // 기다리는 간격 서버 과부하 없게 잘 조정하는 과정 필요!
-                WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+                WebDriverWait wait = new WebDriverWait(driver, Duration.ofMinutes(15));
                 wait.until(ExpectedConditions.presenceOfElementLocated(By.className("txt_lineup")));
 
                 // 홈팀과 원정팀의 선발 라인업 포메이션 정보를 문자열로 크롤링
@@ -101,9 +101,9 @@ public class LineupCrawler {
                 Logger.getGlobal().log(Level.INFO, "lineup driver 로딩 시간 초과");
                 matchLineup = null;
             }
+            WebDriverUtil.close(driver);
         }
-
-        driver.quit();
+        WebDriverUtil.quit(driver);
         return matchLineup;
     }
     // 팀별 포메이션 정보 반환하는 함수

--- a/src/main/java/KickIt/server/global/common/crawler/test.java
+++ b/src/main/java/KickIt/server/global/common/crawler/test.java
@@ -1,6 +1,8 @@
 package KickIt.server.global.common.crawler;
 
 import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.lineup.entity.MatchLineup;
+import KickIt.server.domain.teams.entity.Player;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,12 +17,35 @@ public class test {
         String year = String.valueOf(LocalDate.now().getYear());
         String month = String.format("%02d", LocalDate.now().getMonthValue());
         List<Fixture> fixtureList = mayFixtureCrawler.getFixture(year, month);
+        // fixtureCrawler 테스트 및 출력
+        /*
         for(int i = 0; i < fixtureList.size(); i++){
             Fixture fixture = fixtureList.get(i);
-            Logger.getGlobal().log(Level.INFO, String.format("%s\n%s\n%s\n%s vs %s\n%s : %s\n%sR\n%s\n",
+            Logger.getGlobal().log(Level.INFO, String.format("%s\n%s\n%s\n%s vs %s\n%s : %s\n%sR\n%s\n%s\n",
                     fixture.getId(), fixture.getSeason(), fixture.getDate(), fixture.getHomeTeam(), fixture.getAwayTeam(),
-                    fixture.getHomeTeamScore(), fixture.getAwayteamScore(), fixture.getRound(), fixture.getStatus()));
+                    fixture.getHomeTeamScore(), fixture.getAwayteamScore(), fixture.getRound(), fixture.getStatus(), fixture.getLineupUrl()));
+        }
+        */
+        LineupCrawler lineupCrawler = new LineupCrawler();
+        MatchLineup lineup = lineupCrawler.getLineup(fixtureList.get(0));
+        if (lineup != null){
+            Logger.getGlobal().log(Level.INFO, String.format("%s\n %s\n %s\n %s\n %s\n %s\n %s\n", lineup.getId(), lineup.getHomeTeam(), lineup.getAwayTeam(), lineup.getHomeTeamForm(), lineup.getAwayTeamForm(), lineup.getHomeTeamLineup().getDirector(), lineup.getAwayTeamLineup().getDirector()));
+            for (int i = 0; i < 11; i++){
+                Player player =  lineup.getHomeTeamLineup().getPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("hometeam 선수 명단 \n %s %s %s %s\n", player.getId(), player.getNumber(), player.getName(), player.getPosition()));
+            }
+            for (int i = 0; i < 11; i++){
+                Player player =  lineup.getAwayTeamLineup().getPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("awayteam 선수 명단 \n %s %s %s %s\n", player.getId(), player.getNumber(), player.getName(), player.getPosition()));
+            }
+            for (int i = 0; i < lineup.getHomeTeamLineup().getBenchPlayers().size(); i++){
+                Player benchPlayer =  lineup.getHomeTeamLineup().getBenchPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("hometeam 후보 선수 명단 \n %s %s %s %s\n", benchPlayer.getId(), benchPlayer.getNumber(), benchPlayer.getName(), benchPlayer.getPosition()));
+            }
+            for (int i = 0; i < lineup.getAwayTeamLineup().getBenchPlayers().size(); i++){
+                Player benchPlayer =  lineup.getAwayTeamLineup().getBenchPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("awayteam 후보 선수 명단 \n %s %s %s %s\n", benchPlayer.getId(), benchPlayer.getNumber(), benchPlayer.getName(), benchPlayer.getPosition()));
+            }
         }
     }
 }
-

--- a/src/main/java/KickIt/server/global/util/WebDriverUtil.java
+++ b/src/main/java/KickIt/server/global/util/WebDriverUtil.java
@@ -28,7 +28,7 @@ public class WebDriverUtil {
         // webDriver 옵션 설정
         ChromeOptions chromeOptions = new ChromeOptions();
 
-        chromeOptions.addArguments("--headless=new");
+        //chromeOptions.addArguments("--headless=new");
         chromeOptions.addArguments("--lang=ko");
         chromeOptions.addArguments("--no-sandbox");
         chromeOptions.addArguments("--disable-dev-shm-usage");


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #6 
<br>
closed jira #SF-42

## ✨ 변경 사항 및 이유
- 경기 시작 전 선발 라인업이 공개 되지 않아 라인업 WebElement 존재하지 않을 시 15 분 기다리고 존재 시 크롤링 코드 수행, 실패 시 null 반환하는 처리
- 각 경기별 선발 라인업 모델 클래스 생성 
- 경기 선발 라인업 클래스에 포함될 각 팀 별 선발 라인업 모델 클래스 생성
- 선수 정보 저장할 Player 모델 클래스 생성
- 선발 라인업 공개 시 팀별 선수 포메이션 정보 크롤링
- 선발 라인업 공개 시 팀별 선수 명단 크롤링
- 선발 라인업 정보에 감독 / 후보 선수 정보 추가