### PR TITLE
🎉 Feat: 팀별 선수 명단 정보 크롤링하는 SquadCrawler 추가

### DIFF
--- a/src/main/java/KickIt/server/domain/teams/EplTeams.java
+++ b/src/main/java/KickIt/server/domain/teams/EplTeams.java
@@ -5,43 +5,54 @@ import java.util.Map;
 
 // 현재 상위 20 개 EPL 팀
 public enum EplTeams {
-    MCI("Manchester City", "맨시티"),
-    ARS("Arsenal", "아스널"),
-    LIV("Liverpool", "리버풀"),
-    AVL("Aston Villa", "애스턴 빌라"),
-    TOT("Tottenham Hotspur", "토트넘"),
-    NEW("Newcastle United", "뉴캐슬"),
-    CHE("Chelsea", "첼시"),
-    MUN("Manchester United", "맨유"),
-    WHU("West Ham United", "웨스트햄"),
-    BHA("Brighton and Hove Albion", "브라이튼"),
-    BOU("AFC Bournemouth", "본머스"),
-    CRY("Crystal Palace", "크리스탈 팰리스"),
-    WOL("Wolverhampton Wanderers", "울버햄튼"),
-    FUL("Fulham", "풀럼"),
-    EVE("Everton", "에버턴"),
-    BRE("Brentford", "브렌트포드"),
-    NFO("Nottingham Forest", "노팅엄"),
-    LUT("Luton Town", "루턴 타운"),
-    BUR("Burnley", "번리"),
-    SHU("Sheffield United", "셰필드")
+    MCI("Manchester City", "맨시티", "맨체스터 시티"),
+    ARS("Arsenal", "아스널", "아스널"),
+    LIV("Liverpool", "리버풀", "리버풀"),
+    AVL("Aston Villa", "애스턴 빌라", "애스턴 빌라"),
+    TOT("Tottenham Hotspur", "토트넘", "토트넘 홋스퍼"),
+    NEW("Newcastle United", "뉴캐슬", "뉴캐슬 유나이티드"),
+    CHE("Chelsea", "첼시","첼시"),
+    MUN("Manchester United", "맨유", "맨체스터 유나이티드"),
+    WHU("West Ham United", "웨스트햄", "웨스트햄 유나이티드"),
+    BHA("Brighton and Hove Albion", "브라이튼", "브라이튼 앤 호브 알비온"),
+    BOU("AFC Bournemouth", "본머스", "AFC 본머스"),
+    CRY("Crystal Palace", "크리스탈 팰리스", "크리스탈 팰리스"),
+    WOL("Wolverhampton Wanderers", "울버햄튼", "울버햄튼 원더러스"),
+    FUL("Fulham", "풀럼", "풀럼"),
+    EVE("Everton", "에버턴", "에버턴"),
+    BRE("Brentford", "브렌트포드", "브렌트포드"),
+    NFO("Nottingham Forest", "노팅엄", "노팅엄 포레스트"),
+    LUT("Luton Town", "루턴 타운", "루턴 타운"),
+    BUR("Burnley", "번리", "번리"),
+    SHU("Sheffield United", "셰필드", "셰필드 유나이티드")
     ;
     private final String engName;
     private final String krName;
+    private final String krFullName;
 
-    EplTeams(String engName, String krName){
+    EplTeams(String engName, String krName, String krFullName){
         this.engName = engName;
         this.krName = krName;
+        this.krFullName = krFullName;
     }
-    // 한국어 이름으로 EPLTEAM 찾을 수 있도록 MAP 사용
+    // 한국어 이름으로 EplTeam 찾을 수 있도록 Map 사용
     private static final Map<String, EplTeams> BY_KRNAME = new HashMap<>();
+    // 한국어 풀네임으로 EplTeam 찾을 수 있도록 Map 사용
+    private static final Map<String, EplTeams> BY_KRFULLNAME = new HashMap<>();
+
     static {
         for(EplTeams e : values()){
             BY_KRNAME.put(e.krName, e);
+            BY_KRFULLNAME.put(e.krFullName, e);
         }
     }
-    // 한국어 이름으로 해당 되는 EplTeam 찾아 반환
+
+    // 한국어 이름으로 해당되는 EplTeam 찾아 반환
     public static EplTeams valueOfKrName(String krName){
         return BY_KRNAME.get(krName);
+    }
+    // 한국어 풀네임으로 해당되는 EplTeam 찾아 반환
+    public static EplTeams valueOfKrFullName(String krFullName){
+        return BY_KRFULLNAME.get(krFullName);
     }
 }

--- a/src/main/java/KickIt/server/domain/teams/PlayerPosition.java
+++ b/src/main/java/KickIt/server/domain/teams/PlayerPosition.java
@@ -1,0 +1,13 @@
+package KickIt.server.domain.teams;
+
+// 선수들의 포지션 분류
+public enum PlayerPosition {
+    // 골키퍼(Goalkeeper)
+    GK,
+    // 공격수(Forward)
+    FW,
+    // 미드필더(Midfielder)
+    MF,
+    // 수비수(Defender)
+    DF
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -1,6 +1,7 @@
 package KickIt.server.domain.teams.entity;
 
 import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.PlayerPosition;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,9 +20,10 @@ public class Player {
     // 선수 소속팀
     private EplTeams team;
     // 선수 등번호
-    private int number;
+    // 선수 번호 데이터가 없는 경우 null 값 주므로 이를 수용하기 위해 int -> Integer로 변경
+    private Integer number;
     // 선수 이름
     private String name;
     // 선수 포지션
-    private String position;
+    private PlayerPosition position;
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/Squad.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Squad.java
@@ -1,0 +1,27 @@
+package KickIt.server.domain.teams.entity;
+
+import KickIt.server.domain.teams.EplTeams;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// 각 팀별 선수 목록을 나타내기 위한 PlayerRepository
+public class Squad {
+    // 팀 이름
+    private EplTeams team;
+    // 공격수(Forward) 선수 리스트
+    private ArrayList<Player> FWplayers;
+    // 미드필더(Midfielder) 선수 리스트
+    private ArrayList<Player> MFplayers;
+    // 수비수(Defender) 선수 리스트
+    private ArrayList<Player> DFplayers;
+    // 골키퍼(Goalkeeper) 선수 리스트
+    private ArrayList<Player> GKplayers;
+}

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -30,7 +30,7 @@ public class FixtureCrawler {
         if (!ObjectUtils.isEmpty(driver)) {
             // 페이지 열고 타임 아웃 관련 처리
             driver.get(pageUrl);
-            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
             // 현재 시즌 정보를 불러와 변수로 저장 -> 이후 읽어 들인 페이지의 모든 경기에 정보 넣어 줌
             String season = driver.findElement(By.className("emph_day")).getText();
             // 페이지에서 불러온 경기 일정 table fixtureTable에 저장

--- a/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
@@ -1,0 +1,109 @@
+package KickIt.server.global.common.crawler;
+
+import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.PlayerPosition;
+import KickIt.server.domain.teams.entity.Player;
+import KickIt.server.domain.teams.entity.Squad;
+import KickIt.server.global.util.WebDriverUtil;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.util.ObjectUtils;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// 현재 시즌의 팀별 선수 명단을 크롤링하기 위한 SquadCrawler
+public class SquadCrawler {
+    Map<EplTeams, Squad> getTeamSquads(){
+        WebDriver driver = WebDriverUtil.getChromeDriver();
+        // 다음 스포츠의 프리미어리그 팀 페이지
+        String pageUrl = "https://sports.daum.net/team/epl";
+        // 현 시즌의 각 팀 선수 명단을 저장하고 있는 Map 객체 seasonSquads
+        Map<EplTeams, Squad> seasonSquads = new HashMap<>();
+        List<String> teamPageUrls = new ArrayList<>();
+        if (!ObjectUtils.isEmpty(driver)) {
+            driver.get(pageUrl);
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+            try{
+                // 다음 스포츠의 팀 페이지에서 각 팀의 상세 페이지 url을 가져 온다.
+                List<WebElement> teamPages = driver.findElements(By.cssSelector("div.cont_item > a.link_cont"));
+                for (int i = 0; i < teamPages.size(); i++){
+                    String href = teamPages.get(i).getAttribute("href");
+                    // 가져온 상세 페이지 url에서 필요한 부분만 잘라내고, 뒤에 squad를 붙여 팀별 선수 명단 페이지 url을 만든다.
+                    // 이후 해당 문자열을 teamPageUrls에 저장한다.
+                    teamPageUrls.add(href.substring(0, href.length()-4) + "squad");
+                }
+
+                // 위에서 가져온 각 팀별 상세 페이지 url을 크롤링 완료 후 squad 객체를 반환하는 getSquad 메소드에 매개변수로 전달한다.
+                // 이후 결과로 전달 받은 sqaud 객체를 Map<EplTeam, Squad>로 만들어 크롤러가 결과로 반환할 seasonSquads에 추가한다.
+                for (int i = 0; i < 20; i++){
+                    /* page url 제대로 크롤링했는지 확인하기 위한 코드. 추후 삭제 예정. */
+                    System.out.println(teamPageUrls.get(i));
+                    Squad squad = getSquad(driver, teamPageUrls.get(i));
+                    seasonSquads.put(squad.getTeam(), squad);
+                }
+
+            }
+            // 예외 처리
+            catch (Exception e){
+                Logger.getGlobal().log(Level.INFO, e.toString());
+                // 문제 있는 경우 null 반환
+                seasonSquads = null;
+            }
+            // 완료 후 모든 창 종료
+            finally {
+                driver.quit();
+            }
+        }
+
+        return seasonSquads;
+    }
+
+    // 각 팀의 선수 상세 페이지를 크롤링해 팀 선수 명단인 Squad 객체를 반환하는 getSquad()
+    Squad getSquad(WebDriver driver, String url){
+        driver.get(url);
+        // 포지션별로 나누어진 선수 명단 정보가 있는 WebElements 찾아옴 (총 4 개- 0: 공격수 1: 미드필더 2: 수비수 3: 골키퍼)
+        List<WebElement> squadElements = driver.findElements(By.className("list_member"));
+        // 팀 이름 문자열 가져온 후 팀의 한국어 풀네임으로 EplTeams를 찾아 반환 받는다.
+        EplTeams team = EplTeams.valueOfKrFullName(driver.findElement(By.cssSelector("div.basic_feature > div.cont_thumb > h3.tit_thumb ")).getText());
+        /* team data 제대로 크롤링했는지 확인하기 위한 코드. 추후 삭제 예정. */
+        Logger.getGlobal().log(Level.INFO, String.format("%s", team));
+        // 포지션별 선수 명단 element마다 getPosPlayers 함수를 호출해, Player list를 반환 받는다.
+        // 이후 team과 포지션별 선수 명단 데이터로 Squad 객체 teamSquad를 build 후 반환한다.
+        Squad teamSquad = Squad.builder()
+                            .team(team)
+                            .FWplayers(getPosPlayers(squadElements.get(0).findElements(By.tagName("li")), team, PlayerPosition.FW))
+                            .MFplayers(getPosPlayers(squadElements.get(1).findElements(By.tagName("li")), team, PlayerPosition.MF))
+                            .DFplayers(getPosPlayers(squadElements.get(2).findElements(By.tagName("li")), team, PlayerPosition.DF))
+                            .GKplayers(getPosPlayers(squadElements.get(3).findElements(By.tagName("li")), team, PlayerPosition.GK))
+                            .build();
+        return teamSquad;
+    }
+
+    // 팀 선수 명단 내의 포지션 별 선수 리스트를 크롤링해 반환하는 함수 getPosPlayers()
+    ArrayList<Player> getPosPlayers(List<WebElement> playerInfos, EplTeams team, PlayerPosition pos){
+        ArrayList<Player> posPlayers = new ArrayList<>();
+        for(int i = 0; i < playerInfos.size(); i++){
+            // 선수 이름 크롤링
+            String name = playerInfos.get(i).findElement(By.cssSelector("strong.tit_thumb")).getText();
+            // 선수 번호(No. 00 형태 문자열) 크롤링 후 0~9 사이 숫자가 아니면 모두 ""로 변환
+            String num = playerInfos.get(i).findElement(By.cssSelector("span.txt_thumb")).getText().replaceAll("[^0-9]", "");
+            // 생성한 고유 id, 매개변수로 전달 받은 team과 position, 크롤링 해온 number과 name 데이터로 새로운 Player 객체를 build하고,
+            // 포지션 별 선수 리스트 posPlayers에 추가한다.
+            Player player = Player.builder()
+                    .id(UUID.randomUUID())
+                    .team(team)
+                    .number(num.equals("")? null : Integer.parseInt(num))
+                    .name(name)
+                    .position(pos)
+                    .build();
+            /* 각 선수 정보 제대로 크롤링했는지 확인하기 위한 코드. 추후 삭제 예정. */
+            Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", player.getId(), player.getNumber(), player.getName(), player.getPosition().toString()));
+            posPlayers.add(player);
+        }
+        return posPlayers;
+    }
+}

--- a/src/main/java/KickIt/server/global/common/crawler/test.java
+++ b/src/main/java/KickIt/server/global/common/crawler/test.java
@@ -1,33 +1,26 @@
 package KickIt.server.global.common.crawler;
 
-import KickIt.server.domain.fixture.entity.Fixture;
-import KickIt.server.domain.lineup.entity.MatchLineup;
-import KickIt.server.domain.teams.entity.Player;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 public class test {
 
     public static void main(String[] args) {
 
+        // fixtureCrawler 테스트 및 출력
+        /*
         FixtureCrawler mayFixtureCrawler = new FixtureCrawler();
         String year = String.valueOf(LocalDate.now().getYear());
         String month = String.format("%02d", LocalDate.now().getMonthValue());
         List<Fixture> fixtureList = mayFixtureCrawler.getFixture(year, month);
 
-        // fixtureCrawler 테스트 및 출력
-        /*
         for(int i = 0; i < fixtureList.size(); i++){
             Fixture fixture = fixtureList.get(i);
             Logger.getGlobal().log(Level.INFO, String.format("%s\n%s\n%s\n%s vs %s\n%s : %s\n%sR\n%s\n%s\n",
                     fixture.getId(), fixture.getSeason(), fixture.getDate(), fixture.getHomeTeam(), fixture.getAwayTeam(),
                     fixture.getHomeTeamScore(), fixture.getAwayteamScore(), fixture.getRound(), fixture.getStatus(), fixture.getLineupUrl()));
         }
-        */
-        
+         */
+
+        // LineupCrawler 테스트 및 출력
+        /*
         LineupCrawler lineupCrawler = new LineupCrawler();
         MatchLineup lineup = lineupCrawler.getLineup(fixtureList.get(0));
         if (lineup != null){
@@ -49,6 +42,10 @@ public class test {
                 Logger.getGlobal().log(Level.INFO, String.format("awayteam 후보 선수 명단 \n %s %s %s %s\n", benchPlayer.getId(), benchPlayer.getNumber(), benchPlayer.getName(), benchPlayer.getPosition()));
             }
         }
+         */
+        // PlayerCralwer 테스트 및 출력
+        SquadCrawler squadCrawler = new SquadCrawler();
+        squadCrawler.getTeamSquads();
     }
 }
 


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #7 
<br>
closed jira #SF-43

## ✨ 변경 사항 및 이유
- 프리미어리그 팀별 선수 명단을 모델 클래스 Squad로 생성
- 선수 포지션을 간단하게 표현하기 위한 Enum(PlayerPosition) 추가(GK(골키퍼), FW(공격수), MF(미드필더), DF(수비수))
- 현 시즌 1부 리그 팀들의 선수 명단을 크롤링해 가져와 클래스 객체에 저장한다. 
   (선수 고유 id + 팀 + 선수 번호 + 선수 포지션 => Player 객체 생성)
   (팀 + 포지션 별로 생성한 Player List => Squad 객체 생성)
- 다음 스포츠의 팀 / 선수 페이지와 각 팀 상세 페이지에 나와 있는 팀명이 경기 일정에서 나오는 팀명과 달라, 미리 만들어 둔 EplTeams enum에서 한국어 이름 값으로 Enum을 찾을 때 발생하는 오류 해결
- 뉴캐슬 선수 데이터에서의 한 선수의 선수 번호 데이터 누락으로 인해 선수 번호 int로 변환 시 발생한 오류 해결 (Integer로 변환, 번호 없는 경우 null 처리)
