### PR TITLE
🎉feat: 기존 시즌 선수 명단에 공식 선수 프로필 이미지 주소 추가 크롤링

### DIFF
--- a/src/main/java/KickIt/server/domain/teams/EplTeams.java
+++ b/src/main/java/KickIt/server/domain/teams/EplTeams.java
@@ -39,11 +39,14 @@ public enum EplTeams {
     private static final Map<String, EplTeams> BY_KRNAME = new HashMap<>();
     // 한국어 풀네임으로 EplTeam 찾을 수 있도록 Map 사용
     private static final Map<String, EplTeams> BY_KRFULLNAME = new HashMap<>();
+    // 영어 풀네임으로 EplTeam 찾을 수 있도록 Map 사용
+    private static final Map<String, EplTeams> BY_ENGNAME = new HashMap<>();
 
     static {
         for(EplTeams e : values()){
             BY_KRNAME.put(e.krName, e);
             BY_KRFULLNAME.put(e.krFullName, e);
+            BY_ENGNAME.put(e.engName, e);
         }
     }
 
@@ -55,4 +58,6 @@ public enum EplTeams {
     public static EplTeams valueOfKrFullName(String krFullName){
         return BY_KRFULLNAME.get(krFullName);
     }
+    // 영어 이름으로 해당되는 EplTeam 찾아 반환
+    public static EplTeams valueOfEngName(String engName){ return BY_ENGNAME.get(engName); }
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -26,4 +26,6 @@ public class Player {
     private String name;
     // 선수 포지션
     private PlayerPosition position;
+    // 이미지 주소
+    private String profileImg;
 }

--- a/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
@@ -6,7 +6,6 @@ import KickIt.server.domain.teams.entity.Player;
 import KickIt.server.domain.teams.entity.Squad;
 import KickIt.server.global.util.WebDriverUtil;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -36,7 +35,7 @@ public class SquadCrawler {
         if (!ObjectUtils.isEmpty(driver)) {
             try{
                 driver.get(pageUrl);
-                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+                Thread.sleep(50);
                 // 다음 스포츠의 팀 페이지에서 각 팀의 상세 페이지 url을 가져 온다.
                 List<WebElement> teamPages = driver.findElements(By.cssSelector("div.cont_item > a.link_cont"));
                 for (int i = 0; i < teamPages.size(); i++){
@@ -45,48 +44,42 @@ public class SquadCrawler {
                     // 이후 해당 문자열을 teamPageUrls에 저장한다.
                     teamPageUrls.add(href.substring(0, href.length()-4) + "squad");
                 }
-                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+                Thread.sleep(50);
 
-                WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60));
+                // EPL 공식 사이트의 랭킹 table에서 각 팀 페이지 주소를 가져와 teamPageUrls에 저장한다.
                 try{
-                    driver.get("https://www.premierleague.com");
+                    // flex layout element에서 stale error 발생 방지하기 위한 브라우저 크기 조절
+                    driver.manage().window().setSize(new org.openqa.selenium.Dimension(1400, 800));
+                    // EPL 공식 사이트 크롤링
+                    driver.get("https://www.premierleague.com/home");
 
-                    wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("Button#onetrust-accept-btn-handler")));
+                    // 첫 방문 시 쿠키 허용을 위해 accept button 클릭 가능할 때까지 명시적으로 대기 -> 클릭
+                    new WebDriverWait(driver, Duration.ofSeconds(30)).until(ExpectedConditions.elementToBeClickable(By.cssSelector("Button#onetrust-accept-btn-handler")));
                     driver.findElement(By.cssSelector("Button#onetrust-accept-btn-handler")).click();
-                    driver.manage().addCookie(new Cookie("eplOfficial", "accept"));
+
+                    // 본 페이지의 랭킹 테이블의 td.teams 모두 보일 때까지 100 밀리초 대기 + 명시적 대기
+                    Thread.sleep(100);
+                    new WebDriverWait(driver, Duration.ofSeconds(30)).until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.cssSelector("td.team > a")));
+
+                    // 각 팀 페이지 url 가져와 저장
+                    driver.findElements(By.cssSelector("td.team > a")).forEach(s -> officialPageUrls.add(s.getAttribute("href").replace("overview", "squad")));
+                    officialPageUrls.forEach(s -> getPlayerImgs(imageUrls, driver, s));
                 }
+                // 예외 처리
                 catch (Exception e){
                     Logger.getGlobal().log(Level.WARNING, e.toString());
                 }
-                try{
-                    driver.get("https://www.premierleague.com");
-                    driver.manage().getCookieNamed("eplOfficial");
 
-                    wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("td.team")));
-                    driver.findElements(By.cssSelector("td.team > a")).forEach(s -> officialPageUrls.add(s.getAttribute("href").replace("overview", "squad")));
-                    /* 가져온 EPL 공식 사이트 팀별 url 출력하는 코드 추후 삭제 예정 */
-                    officialPageUrls.forEach(s -> Logger.getGlobal().log(Level.INFO, s));
-                }
-                catch(Exception e){
-                    Logger.getGlobal().log(Level.WARNING, e.toString());
-                }
-
-                for (int i = 0; i < teamPages.size(); i++){
-
-                }
-
-                /*
                 // 위에서 가져온 각 팀별 상세 페이지 url을 크롤링 완료 후 squad 객체를 반환하는 getSquad 메소드에 매개변수로 전달한다.
                 // 이후 결과로 전달 받은 sqaud 객체를 Map<EplTeam, Squad>로 만들어 크롤러가 결과로 반환할 seasonSquads에 추가한다.
                 for (int i = 0; i < 20; i++){
                     // page url 제대로 크롤링했는지 확인하기 위한 코드. 추후 삭제 예정.
                     System.out.println(teamPageUrls.get(i));
-                    Squad squad = getSquad(driver, teamPageUrls.get(i));
+                    Squad squad = getSquad(driver, teamPageUrls.get(i), imageUrls);
                     seasonSquads.put(squad.getTeam(), squad);
                 }
-                */
 
-                Thread.sleep(10);
+                Thread.sleep(50);
                 driver.quit();
             }
             // 예외 처리
@@ -101,8 +94,34 @@ public class SquadCrawler {
         return seasonSquads;
     }
 
+    // 각 팀 페이지에 방문해 해당 팀 EplTeams를 key 값으로, 선수 이미지 목록을 담은 Map<선수 번호, 이미지 주소>를 value 값으로 map에 넣어 줌
+    void getPlayerImgs(Map<EplTeams, Map<Integer, String>> map, WebDriver driver, String pageUrl){
+        driver.get(pageUrl);
+        // 크롤링해 온 영어 풀네임으로 EplTeams 반환 받음
+        EplTeams team = EplTeams.valueOfEngName(driver.findElement(By.cssSelector("h2.club-header__team-name")).getText());
+
+        // 팀의 선수들의 프로필 이미지 주소를 이후 다음 스포츠 페이지 크롤링 기반으로 Player 객체 build 할때 쉽게 찾아올 수 있도록
+        // 선수 번호를 key 값으로 선수 프로필 이미지 주소 value를 찾아오는 map 만듦
+        Map<Integer, String> playerImgs = new HashMap<>();
+        List<String> numList = new ArrayList<>();
+        List<String> urlList = new ArrayList<>();
+        driver.findElements(By.cssSelector("div.stats-card__squad-number.u-hide-mob-l")).forEach(e -> numList.add(e.getText()));
+        driver.findElements(By.cssSelector("img.statCardImg.statCardPlayer")).forEach(e -> urlList.add(e.getAttribute("src")));
+
+
+        for(int i = 0; i < numList.size(); i++){
+            // numList가 공백인 경우(선수 번호 없는 경우) Integer로 parsing 할 경우 오류 발생하므로 continue
+            // (번호 없어 map으로 찾을 수 없으므로 이미지 주소 저장할 필요 없음)
+            if(numList.get(i).equals("")){ continue; }
+            // map 'playerImgs'에 (선수 이름, 크롤링한 프로필 이미지 주소) put
+            playerImgs.put(Integer.parseInt(numList.get(i)), urlList.get(i));
+        }
+        // map 'map'에 (팀, 선수 이미지 주소들 담은 map'playerImgs') put
+        map.put(team, playerImgs);
+    }
+
     // 각 팀의 선수 상세 페이지를 크롤링해 팀 선수 명단인 Squad 객체를 반환하는 getSquad()
-    Squad getSquad(WebDriver driver, String url){
+    Squad getSquad(WebDriver driver, String url, Map<EplTeams, Map<Integer, String>> imageUrl){
         driver.get(url);
         // 포지션별로 나누어진 선수 명단 정보가 있는 WebElements 찾아옴 (총 4 개- 0: 공격수 1: 미드필더 2: 수비수 3: 골키퍼)
         List<WebElement> squadElements = driver.findElements(By.className("list_member"));
@@ -112,35 +131,42 @@ public class SquadCrawler {
         Logger.getGlobal().log(Level.INFO, String.format("%s", team));
         // 포지션별 선수 명단 element마다 getPosPlayers 함수를 호출해, Player list를 반환 받는다.
         // 이후 team과 포지션별 선수 명단 데이터로 Squad 객체 teamSquad를 build 후 반환한다.
+        Map<Integer, String> images = imageUrl.get(team);
         Squad teamSquad = Squad.builder()
                             .team(team)
-                            .FWplayers(getPosPlayers(squadElements.get(0).findElements(By.tagName("li")), team, PlayerPosition.FW))
-                            .MFplayers(getPosPlayers(squadElements.get(1).findElements(By.tagName("li")), team, PlayerPosition.MF))
-                            .DFplayers(getPosPlayers(squadElements.get(2).findElements(By.tagName("li")), team, PlayerPosition.DF))
-                            .GKplayers(getPosPlayers(squadElements.get(3).findElements(By.tagName("li")), team, PlayerPosition.GK))
+                            .FWplayers(getPosPlayers(squadElements.get(0).findElements(By.tagName("li")), team, PlayerPosition.FW, images))
+                            .MFplayers(getPosPlayers(squadElements.get(1).findElements(By.tagName("li")), team, PlayerPosition.MF, images))
+                            .DFplayers(getPosPlayers(squadElements.get(2).findElements(By.tagName("li")), team, PlayerPosition.DF, images))
+                            .GKplayers(getPosPlayers(squadElements.get(3).findElements(By.tagName("li")), team, PlayerPosition.GK, images))
                             .build();
         return teamSquad;
     }
 
     // 팀 선수 명단 내의 포지션 별 선수 리스트를 크롤링해 반환하는 함수 getPosPlayers()
-    ArrayList<Player> getPosPlayers(List<WebElement> playerInfos, EplTeams team, PlayerPosition pos){
+    ArrayList<Player> getPosPlayers(List<WebElement> playerInfos, EplTeams team, PlayerPosition pos, Map<Integer, String> images){
         ArrayList<Player> posPlayers = new ArrayList<>();
         for(int i = 0; i < playerInfos.size(); i++){
             // 선수 이름 크롤링
             String name = playerInfos.get(i).findElement(By.cssSelector("strong.tit_thumb")).getText();
             // 선수 번호(No. 00 형태 문자열) 크롤링 후 0~9 사이 숫자가 아니면 모두 ""로 변환
-            String num = playerInfos.get(i).findElement(By.cssSelector("span.txt_thumb")).getText().replaceAll("[^0-9]", "");
+            String numText = playerInfos.get(i).findElement(By.cssSelector("span.txt_thumb")).getText().replaceAll("[^0-9]", "");
             // 생성한 고유 id, 매개변수로 전달 받은 team과 position, 크롤링 해온 number과 name 데이터로 새로운 Player 객체를 build하고,
             // 포지션 별 선수 리스트 posPlayers에 추가한다.
+            Integer num = numText.equals("")? null : Integer.parseInt(numText);
+            // 공식 팀 페이지에서 이미지 주소들을 가져오지 못해 images가 null 인 경우 선수 개인 이미지 주소 null 처리,
+            // 그렇지 않은 경우 images에서 num을 key 값으로 이미지 주소 찾아 와 저장.
+            String img = images == null? null: images.get(num);
             Player player = Player.builder()
                     .id(UUID.randomUUID())
                     .team(team)
-                    .number(num.equals("")? null : Integer.parseInt(num))
+                    .number(num)
                     .name(name)
                     .position(pos)
+                    // img가 null인 경우 epl 공식 사이트의 선수 이미지 없을 때의 sample image로, 가지고 있는 img 있는 경우 그 주소로 build
+                    .profileImg(img == null ? "https://resources.premierleague.com/premierleague/photos/players/110x140/Photo-Missing.png" : img)
                     .build();
             /* 각 선수 정보 제대로 크롤링했는지 확인하기 위한 코드. 추후 삭제 예정. */
-            //Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s", player.getId(), player.getNumber(), player.getName(), player.getPosition().toString()));
+            Logger.getGlobal().log(Level.INFO, String.format("%s %s %s %s %s", player.getId(), player.getNumber(), player.getName(), player.getPosition().toString(), player.getProfileImg()));
             posPlayers.add(player);
         }
         return posPlayers;

--- a/src/main/java/KickIt/server/global/common/crawler/test.java
+++ b/src/main/java/KickIt/server/global/common/crawler/test.java
@@ -1,0 +1,76 @@
+package KickIt.server.global.common.crawler;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.lineup.entity.MatchLineup;
+import KickIt.server.domain.teams.entity.Player;
+import KickIt.server.global.util.WebDriverUtil;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class test {
+
+    public static void main(String[] args) {
+
+        /*// fixtureCrawler 테스트 및 출력
+        FixtureCrawler mayFixtureCrawler = new FixtureCrawler();
+        String year = String.valueOf(LocalDate.now().getYear());
+        String month = String.format("%02d", LocalDate.now().getMonthValue());
+        List<Fixture> fixtureList = mayFixtureCrawler.getFixture(year, month);
+
+
+        *//*
+        for(int i = 0; i < fixtureList.size(); i++){
+            Fixture fixture = fixtureList.get(i);
+            Logger.getGlobal().log(Level.INFO, String.format("%s\n%s\n%s\n%s vs %s\n%s : %s\n%sR\n%s\n%s\n",
+                    fixture.getId(), fixture.getSeason(), fixture.getDate(), fixture.getHomeTeam(), fixture.getAwayTeam(),
+                    fixture.getHomeTeamScore(), fixture.getAwayteamScore(), fixture.getRound(), fixture.getStatus(), fixture.getLineupUrl()));
+        }
+         *//*
+
+        LineupCrawler lineupCrawler = new LineupCrawler();
+        MatchLineup lineup = lineupCrawler.getLineup(fixtureList.get(0));
+        if (lineup != null){
+            Logger.getGlobal().log(Level.INFO, String.format("%s\n %s\n %s\n %s\n %s\n %s\n %s\n", lineup.getId(), lineup.getHomeTeam(), lineup.getAwayTeam(), lineup.getHomeTeamForm(), lineup.getAwayTeamForm(), lineup.getHomeTeamLineup().getDirector(), lineup.getAwayTeamLineup().getDirector()));
+
+            ArrayList<List<Player>> homePlayers = lineup.getHomeTeamLineup().getPlayers();
+            for (int i = 0; i < homePlayers.size(); i++){
+                List<Player> homeSubPlayers = homePlayers.get(i);
+                for(int j = 0; j < homeSubPlayers.size(); j++){
+                    Player homePlayer = homeSubPlayers.get(j);
+                    Logger.getGlobal().log(Level.INFO, String.format("hometeam 선수 명단 %s\n %s %s %s %s\n", i, homePlayer.getId(),
+                            homePlayer.getNumber(), homePlayer.getName(), homePlayer.getPosition()));
+                }
+            }
+
+            ArrayList<List<Player>> awayPlayers = lineup.getAwayTeamLineup().getPlayers();
+            for (int i = 0; i < awayPlayers.size(); i++){
+                List<Player> awaySubPlayers = awayPlayers.get(i);
+                for(int j = 0; j < awaySubPlayers.size(); j++){
+                    Player awayPlayer = awaySubPlayers.get(j);
+                    Logger.getGlobal().log(Level.INFO, String.format("awayteam 선수 명단 %s\n %s %s %s %s\n", i, awayPlayer.getId(),
+                            awayPlayer.getNumber(), awayPlayer.getName(), awayPlayer.getPosition()));
+                }
+            }
+
+            for (int i = 0; i < lineup.getHomeTeamLineup().getBenchPlayers().size(); i++){
+                Player benchPlayer =  lineup.getHomeTeamLineup().getBenchPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("hometeam 후보 선수 명단 \n %s %s %s %s\n", benchPlayer.getId(), benchPlayer.getNumber(), benchPlayer.getName(), benchPlayer.getPosition()));
+            }
+            for (int i = 0; i < lineup.getAwayTeamLineup().getBenchPlayers().size(); i++){
+                Player benchPlayer =  lineup.getAwayTeamLineup().getBenchPlayers().get(i);
+                Logger.getGlobal().log(Level.INFO, String.format("awayteam 후보 선수 명단 \n %s %s %s %s\n", benchPlayer.getId(), benchPlayer.getNumber(), benchPlayer.getName(), benchPlayer.getPosition()));
+            }
+        }*/
+
+        // PlayerCralwer 테스트 및 출력
+        SquadCrawler squadCrawler = new SquadCrawler();
+        squadCrawler.getTeamSquads();
+    }
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #13 
<br>
closed jira #SF-48

## ✨ 변경 사항 및 이유
- 프리미어리그 공식 페이지의 공식 프로필 이미지 url을 크롤링 해 현재 시즌의 팀별 선수 명단(Squad)객체에 추가한다.
  (Player 모델 클래스에 공식 프로필 이미지 주소를 저장할 String 변수 추가)
<br>

- 프리미어리그 공식 페이지의 랭킹 목록에 있는 팀 주소를 크롤링해 온 후, 그 주소마다 선수 번호와 선수 이미지를 읽어와 Map<Integer, String>에 add 한다. 
- 이렇게 만들어진 팀별 선수 프로필 이미지 map은 다시 Map<EplTeams, Map<Integer,String>>의 value로 저장해, 이후 팀 선수 명단 객체를 build할 때 전체 팀들의 선수 이미지 주소 map 에서 원하는 팀 key 값> 원하는 선수 key 값으로 공식 프로필 이미지 url 주소를 찾아와 정보 추가해 줄 수 있도록 했다.
- 선수 번호가 null인 경우 / 다음 스포츠에서 크롤링해 온 선수의 선수 번호가 map 안에 없는 경우 / 프리미어리그 공식 사이트에도 사진이 없어 그냥 빈 선수 이미지를 사용하는 경우 => epl 공식 사이트의 빈 프로필 사진 이미지 주를 가져와 반환
<br>

- English Premier League 공식 사이트의 쿠키  허용해야 페이지 내용 볼 수 있는 문제 처리 -> 버튼 click 후 기다렸다가 크롤링 실행
- Run 했을 때 확률적으로 발생하는 staleElementReferenceException: stale element not found in the current frame Error 해결
  1. English Premier League 공식 사이트의 flex layout 때문에 브라우저의 가로폭이 좁아지면 찾고자 하는 Element가 visible 하지 않아 문제 발생 -> 크롤링 시 크롬 브라우저 크기 조절
  2. 불러오고자 하는 데이터가 아직 frame에 없는 건 불러오기 전에 이미 코드가 실행되어서 그런 것으로 분석. 좀 큰 데이터 가지고 올 때마다 자주 thread.sleep 호출하고, thread로 쉬어 주던 시간을 늘렸음. (5초)
