### PR TITLE
🎉 Feat: 한달 경기 일정 조회 GET API 추가(yyyy/MM, teamName으로 데이터 찾아 전달)

### DIFF
--- a/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
+++ b/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
@@ -71,4 +71,44 @@ public class FixtureController {
             return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
         }
     }
+
+    // 입력받은 yyyy-MM으로 해당 월의 경기 일정 모두 반환
+    @GetMapping("/dates")
+    public ResponseEntity<Map<String, Object>> getFixturesByMonth(@RequestParam("yearMonth") @DateTimeFormat(pattern = "yyyy/MM") Date yearMonth, @RequestParam(value="teamName", required = false) String teamName){
+        Map<String, Object> responseBody = new HashMap<>();
+        List<FixtureDto.FixtureDateResponse> responseList;
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(yearMonth);
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH) + 1;
+
+        // teamName이 입력되지 않은 경우 월만으로 경기 조회
+        if(teamName == null){
+            responseList = fixtureService.findFixturesByMonth(year, month);
+            // 입력된 teamName으로 EplTeam이 찾아지지 않는 경우 Bad Request 처리
+        }
+        // teamName이 입력된 경우 날짜와 팀으로 경기 조회
+        else{
+            EplTeams team = EplTeams.valueOfKrName(teamName);
+            if(team == null){
+                responseBody.put("status", HttpStatus.BAD_REQUEST.value());
+                responseBody.put("message", "팀 이름 입력 오류");
+                return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+            }
+            responseList = fixtureService.findFixtureByMonthAndTeam(year, month, team);
+        }
+        // 조회해 가져온 데이터가 존재하는 경우 성공, OK status로 반환
+        if(!responseList.isEmpty()){
+            responseBody.put("status", HttpStatus.OK.value());
+            responseBody.put("message", "success");
+            responseBody.put("data", responseList);
+            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        }
+        // 조회한 list가 비어있는 경우 데이터 없음 처리, NOT FOUND로 반환
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "데이터 없음");
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -5,6 +5,7 @@ import KickIt.server.domain.teams.EplTeams;
 import lombok.*;
 
 import java.sql.Timestamp;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -78,6 +79,18 @@ public class FixtureDto {
             this.round = fixture.getRound();
             this.status = fixture.getStatus();
             this.stadium = fixture.getStadium();
+        }
+    }
+
+    @Getter
+    public static class FixtureDateResponse{
+        private String date;
+
+        // entity to dto
+        public FixtureDateResponse(Fixture fixture){
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+            sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
+            this.date = sdf.format(new Date(fixture.getDate().getTime()));
         }
     }
 }

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -88,7 +88,7 @@ public class FixtureDto {
 
         // entity to dto
         public FixtureDateResponse(Fixture fixture){
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd");
             sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
             this.date = sdf.format(new Date(fixture.getDate().getTime()));
         }

--- a/src/main/java/KickIt/server/domain/fixture/entity/FixtureRepository.java
+++ b/src/main/java/KickIt/server/domain/fixture/entity/FixtureRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.sql.Timestamp;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,10 @@ public interface FixtureRepository extends JpaRepository<Fixture, Long>{
     @Query("SELECT f FROM Fixture f WHERE DATE(f.date) = DATE(:date) AND (f.homeTeam = :team OR f.awayTeam = :team)")
     List<Fixture> findByDateAndTeam(@Param("date") Timestamp date, @Param("team") EplTeams team);
 
+    // Date 중 시간은 버리고 연 / 월이 일치하는 Fixture DB에서 찾아 반환
+    @Query("SELECT f FROM Fixture f WHERE YEAR(f.date) = :year AND MONTH(f.date) = :month")
+    List<Fixture> findByMonth(@Param("year") int year, @Param("month") int month);
+
+    @Query("SELECT f FROM Fixture f WHERE YEAR(f.date) = :year AND MONTH(f.date) = :month AND (f.homeTeam = :team OR f.awayTeam = :team)")
+    List<Fixture> findByMonthAndTeam(@Param("year") int year, @Param("month") int month, @Param("team") EplTeams team);
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -65,4 +65,26 @@ public class FixtureService {
         }
         return responseList;
     }
+
+    // findByMonth로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
+    @Transactional
+    public List<FixtureDto.FixtureDateResponse> findFixturesByMonth(int year, int month){
+        List<Fixture> fixtureList = fixtureRepository.findByMonth(year, month);
+        List<FixtureDto.FixtureDateResponse> responseList = new ArrayList<>();
+        for (Fixture fixture: fixtureList){
+            responseList.add(new FixtureDto.FixtureDateResponse(fixture));
+        }
+        return responseList;
+    }
+
+    // findByMonthAndTeam으로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
+    @Transactional
+    public List<FixtureDto.FixtureDateResponse> findFixtureByMonthAndTeam(int year, int month, EplTeams team){
+        List<Fixture> fixtureList = fixtureRepository.findByMonthAndTeam(year, month, team);
+        List<FixtureDto.FixtureDateResponse> responseList = new ArrayList<>();
+        for (Fixture fixture: fixtureList){
+            responseList.add(new FixtureDto.FixtureDateResponse(fixture));
+        }
+        return responseList;
+    }
 }


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #25 
<br>
closed jira #59

## ✨ 변경 사항 및 이유
- date, teamName을 request param으로 받아 한달 경기 일정 정보를 response body로 return 하는 GET API 구현
- FixtureDto의 response에 경기 일정 정보를 yyyy.MM.dd형태의 List<String>으로 반환하는 dateResponse 추가
- FixtureRepository에 findbyYearAndMonth method 추가
- FixtureRepository에 findbyYearAndMonthAndTeam method 추가
- FixtureController에 한달 경기 일정 정보를 가져오는 GET API method 추가
- 날짜 파라미터 형식이 잘못되었을 때, 팀 이름이 잘못되었을 때, 조건에 해당하는 데이터가 없을 때의 예외 처리 추가
