### PR TITLE
🎉 Feat: 시즌 팀 정보 Entity, 모든 시즌 팀 이름 전체 조회 GET API 추가, enum 대신 DB 조회하도록 전체 코드 수정

### DIFF
--- a/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
+++ b/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
@@ -4,7 +4,7 @@ import KickIt.server.domain.fixture.dto.FixtureDto;
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.fixture.entity.FixtureRepository;
 import KickIt.server.domain.fixture.service.FixtureService;
-import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.service.TeamNameConvertService;
 import KickIt.server.global.common.crawler.FixtureCrawler;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,12 +20,15 @@ import java.util.*;
 public class FixtureController {
     @Autowired
     private FixtureService fixtureService;
+    @Autowired
+    private TeamNameConvertService teamNameConvertService;
+    @Autowired
+    private FixtureCrawler fixtureCrawler;
 
     // 입력 받은 year과 month의 경기 일정을 크롤링해 중복하지 않은 fixture만 db에 save
     @PostMapping("/crawl")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<Map<String, Object>> crawlFixtures (@RequestParam("year") String year, @RequestParam("month") String month){
-        FixtureCrawler fixtureCrawler = new FixtureCrawler();
         List<Fixture> fixtureList = new ArrayList<>();
         fixtureList = fixtureCrawler.getFixture(year, month);
 
@@ -48,7 +51,7 @@ public class FixtureController {
         }
         // teamName이 입력된 경우 날짜와 팀으로 경기 조회
         else {
-            EplTeams team = EplTeams.valueOfKrName(teamName);
+            String team = teamNameConvertService.convertFromKrName(teamName);
             // 입력된 teamName으로 EplTeam이 찾아지지 않는 경우 Bad Request 처리
             if(team == null){
                 responseBody.put("status", HttpStatus.BAD_REQUEST.value());
@@ -89,7 +92,7 @@ public class FixtureController {
         }
         // teamName이 입력된 경우 날짜와 팀으로 경기 조회
         else{
-            EplTeams team = EplTeams.valueOfKrName(teamName);
+            String team = teamNameConvertService.convertFromKrName(teamName);
             if(team == null){
                 responseBody.put("status", HttpStatus.BAD_REQUEST.value());
                 responseBody.put("message", "팀 이름 입력 오류");

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -21,8 +21,8 @@ public class FixtureDto {
         private Long id;
         private String season;
         private Date dateTime;
-        private EplTeams homeTeam;
-        private EplTeams awayTeam;
+        private String homeTeam;
+        private String awayTeam;
         private Integer homeTeamScore;
         private Integer awayteamScore;
         private int round;
@@ -72,8 +72,8 @@ public class FixtureDto {
             this.dateStr = new SimpleDateFormat("yyyy-MM-dd").format(fixture.getDate());
             this.timeStr = new SimpleDateFormat("HH:mm").format(fixture.getDate());
 
-            this.homeTeam = EplTeams.getKrName(fixture.getHomeTeam());
-            this.awayTeam = EplTeams.getKrName(fixture.getAwayTeam());
+            this.homeTeam = fixture.getHomeTeam();
+            this.awayTeam = fixture.getAwayTeam();
             this.homeTeamScore = fixture.getHomeTeamScore();
             this.awayteamScore = fixture.getAwayteamScore();
             this.round = fixture.getRound();

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -2,7 +2,10 @@ package KickIt.server.domain.fixture.dto;
 
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.service.TeamNameConvertService;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -11,7 +14,15 @@ import java.util.Date;
 import java.util.TimeZone;
 import java.util.UUID;
 
+@Component
 public class FixtureDto {
+    private final TeamNameConvertService teamNameConvertService;
+
+    @Autowired
+    public FixtureDto(TeamNameConvertService teamNameConvertService) {
+        this.teamNameConvertService = teamNameConvertService;
+    }
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
@@ -50,7 +61,7 @@ public class FixtureDto {
 
     // fixture response
     @Getter
-    public static class FixtureResponse{
+    public class FixtureResponse{
         private Long id;
         private String season;
         private String dateStr;
@@ -72,8 +83,8 @@ public class FixtureDto {
             this.dateStr = new SimpleDateFormat("yyyy-MM-dd").format(fixture.getDate());
             this.timeStr = new SimpleDateFormat("HH:mm").format(fixture.getDate());
 
-            this.homeTeam = fixture.getHomeTeam();
-            this.awayTeam = fixture.getAwayTeam();
+            this.homeTeam = teamNameConvertService.convertToKrName(fixture.getHomeTeam());
+            this.awayTeam = teamNameConvertService.convertToKrName(fixture.getAwayTeam());
             this.homeTeamScore = fixture.getHomeTeamScore();
             this.awayteamScore = fixture.getAwayteamScore();
             this.round = fixture.getRound();

--- a/src/main/java/KickIt/server/domain/fixture/entity/Fixture.java
+++ b/src/main/java/KickIt/server/domain/fixture/entity/Fixture.java
@@ -28,13 +28,11 @@ public class Fixture {
     @Column(nullable=false)
     private Timestamp date; // 경기 날짜 및 시간
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "ENUM('MCI','ARS','LIV','AVL','TOT','NEW','CHE','MUN','WHU','BHA','BOU','CRY','WOL','FUL','EVE','BRE','NFO','LUT','BUR','SHU') CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
-    private EplTeams homeTeam; // 홈팀 이름
+    @Column(nullable = false)
+    private String homeTeam; // 홈팀 이름
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "ENUM('MCI','ARS','LIV','AVL','TOT','NEW','CHE','MUN','WHU','BHA','BOU','CRY','WOL','FUL','EVE','BRE','NFO','LUT','BUR','SHU') CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
-    private EplTeams awayTeam; // 원정팀 이름
+    @Column(nullable = false)
+    private String awayTeam; // 원정팀 이름
 
     @Column
     private Integer homeTeamScore; // 홈팀 점수

--- a/src/main/java/KickIt/server/domain/fixture/entity/FixtureRepository.java
+++ b/src/main/java/KickIt/server/domain/fixture/entity/FixtureRepository.java
@@ -1,6 +1,5 @@
 package KickIt.server.domain.fixture.entity;
 
-import KickIt.server.domain.teams.EplTeams;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +11,7 @@ import java.util.Optional;
 
 public interface FixtureRepository extends JpaRepository<Fixture, Long>{
     // Date, HomeTeam, AwayTeam이 동일한 Fixture DB에서 찾아 반환
-    Optional<Fixture> findByDateAndHomeTeamAndAwayTeam(Timestamp date, EplTeams homeTeam , EplTeams awayTeam);
+    Optional<Fixture> findByDateAndHomeTeamAndAwayTeam(Timestamp date, String homeTeam , String awayTeam);
 
     // Date 중 시간은 버리고 연 / 월 / 일이 일치하는 Fixture DB에서 찾아 반환
     @Query("SELECT f FROM Fixture f WHERE DATE(f.date) = DATE(:date)")
@@ -20,12 +19,12 @@ public interface FixtureRepository extends JpaRepository<Fixture, Long>{
 
     // Date 중 시간은 버리고 연 / 월 / 일이 일치하고 HomeTeam이나 awayTeam이 team과 일치하는 Fixture DB에서 찾아 반환
     @Query("SELECT f FROM Fixture f WHERE DATE(f.date) = DATE(:date) AND (f.homeTeam = :team OR f.awayTeam = :team)")
-    List<Fixture> findByDateAndTeam(@Param("date") Timestamp date, @Param("team") EplTeams team);
+    List<Fixture> findByDateAndTeam(@Param("date") Timestamp date, @Param("team") String team);
 
     // Date 중 시간은 버리고 연 / 월이 일치하는 Fixture DB에서 찾아 반환
     @Query("SELECT f FROM Fixture f WHERE YEAR(f.date) = :year AND MONTH(f.date) = :month")
     List<Fixture> findByMonth(@Param("year") int year, @Param("month") int month);
 
     @Query("SELECT f FROM Fixture f WHERE YEAR(f.date) = :year AND MONTH(f.date) = :month AND (f.homeTeam = :team OR f.awayTeam = :team)")
-    List<Fixture> findByMonthAndTeam(@Param("year") int year, @Param("month") int month, @Param("team") EplTeams team);
+    List<Fixture> findByMonthAndTeam(@Param("year") int year, @Param("month") int month, @Param("team") String team);
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -16,6 +16,8 @@ import java.util.List;
 public class FixtureService {
     @Autowired
     private FixtureRepository fixtureRepository;
+    @Autowired
+    private FixtureDto fixtureDto;
 
     // fixture List 중 중복되지 않은 fixture만을 저장
     @Transactional
@@ -49,7 +51,7 @@ public class FixtureService {
         List<Fixture> fixtureList = fixtureRepository.findByDate(new Timestamp(date.getTime()));
         List<FixtureDto.FixtureResponse> responseList = new ArrayList<>();
         for (Fixture fixture : fixtureList){
-            responseList.add(new FixtureDto.FixtureResponse(fixture));
+            responseList.add(fixtureDto.new FixtureResponse(fixture));
         }
         return responseList;
     }
@@ -60,7 +62,7 @@ public class FixtureService {
         List<Fixture> fixtureList = fixtureRepository.findByDateAndTeam(new Timestamp(date.getTime()), team);
         List<FixtureDto.FixtureResponse> responseList = new ArrayList<>();
         for (Fixture fixture: fixtureList){
-            responseList.add(new FixtureDto.FixtureResponse(fixture));
+            responseList.add(fixtureDto.new FixtureResponse(fixture));
         }
         return responseList;
     }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -3,7 +3,6 @@ package KickIt.server.domain.fixture.service;
 import KickIt.server.domain.fixture.dto.FixtureDto;
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.fixture.entity.FixtureRepository;
-import KickIt.server.domain.teams.EplTeams;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -57,7 +56,7 @@ public class FixtureService {
 
     // findByDateAndTeam으로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
-    public List<FixtureDto.FixtureResponse> findFixturesByDateAndTeam(Date date, EplTeams team){
+    public List<FixtureDto.FixtureResponse> findFixturesByDateAndTeam(Date date, String team){
         List<Fixture> fixtureList = fixtureRepository.findByDateAndTeam(new Timestamp(date.getTime()), team);
         List<FixtureDto.FixtureResponse> responseList = new ArrayList<>();
         for (Fixture fixture: fixtureList){
@@ -79,7 +78,7 @@ public class FixtureService {
 
     // findByMonthAndTeam으로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
-    public List<FixtureDto.FixtureDateResponse> findFixtureByMonthAndTeam(int year, int month, EplTeams team){
+    public List<FixtureDto.FixtureDateResponse> findFixtureByMonthAndTeam(int year, int month, String team){
         List<Fixture> fixtureList = fixtureRepository.findByMonthAndTeam(year, month, team);
         List<FixtureDto.FixtureDateResponse> responseList = new ArrayList<>();
         for (Fixture fixture: fixtureList){

--- a/src/main/java/KickIt/server/domain/lineup/entity/MatchLineup.java
+++ b/src/main/java/KickIt/server/domain/lineup/entity/MatchLineup.java
@@ -17,9 +17,9 @@ public class MatchLineup {
     // 경기 고유 id
     private Long id;
     // 홈팀
-    private EplTeams homeTeam;
+    private String homeTeam;
     // 원정팀
-    private EplTeams awayTeam;
+    private String awayTeam;
     // 홈팀 포메이션
     private String homeTeamForm;
     // 원정팀 포메이션

--- a/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
+++ b/src/main/java/KickIt/server/domain/lineup/entity/TeamLineup.java
@@ -1,6 +1,5 @@
 package KickIt.server.domain.lineup.entity;
 
-import KickIt.server.domain.teams.EplTeams;
 import KickIt.server.domain.teams.entity.Player;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +16,7 @@ import java.util.List;
 //각 팀별 선발 라인업을 담을 class TeamLineup
 public class TeamLineup {
     // 팀
-    private EplTeams team;
+    private String team;
     // 포메이션
     private String form;
     // 선수 리스트

--- a/src/main/java/KickIt/server/domain/teams/controller/EplTeamController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/EplTeamController.java
@@ -1,0 +1,43 @@
+package KickIt.server.domain.teams.controller;
+
+import KickIt.server.domain.teams.dto.EplTeamDto;
+import KickIt.server.domain.teams.service.EplTeamService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@RestController
+@RequestMapping("/eplTeam")
+public class EplTeamController {
+    @Autowired
+    private EplTeamService eplTeamService;
+
+    @GetMapping("/all")
+    public ResponseEntity<Map<String, Object>> getAllEplTeams(){
+        Map<String, Object> responseBody = new HashMap<>();
+        List<EplTeamDto.EplTeamResponse> responseList;
+        responseList = eplTeamService.FindAllEplTeams();
+
+        // 조회해 가져온 데이터가 존재하는 경우 성공, OK status로 반환
+        if(!responseList.isEmpty()){
+            responseBody.put("status", HttpStatus.OK.value());
+            responseBody.put("message", "success");
+            responseBody.put("data", responseList);
+            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        }
+        // 조회한 list가 비어있는 경우 데이터 없음 처리, NOT FOUND로 반환
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "데이터 없음");
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/dto/EplTeamDto.java
+++ b/src/main/java/KickIt/server/domain/teams/dto/EplTeamDto.java
@@ -1,0 +1,42 @@
+package KickIt.server.domain.teams.dto;
+
+import KickIt.server.domain.teams.entity.EplTeam;
+import lombok.*;
+
+public class EplTeamDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class EplTeamRequest{
+        private String team;
+        private String engName;
+        private String krName;
+        private String krFullName;
+
+        public EplTeam toEntity(){
+            EplTeam eplTeam = EplTeam.builder()
+                    .team(this.team)
+                    .engName(this.engName)
+                    .krName(this.krName)
+                    .krFullName(this.krFullName)
+                    .build();
+            return eplTeam;
+        }
+    }
+
+    @Getter
+    public static class EplTeamResponse{
+        private String team;
+        private String engName;
+        private String krName;
+        private String krFullName;
+
+        public EplTeamResponse(EplTeam eplTeam){
+            this.team = eplTeam.getTeam();
+            this.engName = eplTeam.getEngName();
+            this.krName = eplTeam.getKrName();
+            this.krFullName = eplTeam.getKrFullName();
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/EplTeam.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/EplTeam.java
@@ -1,0 +1,23 @@
+package KickIt.server.domain.teams.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EplTeam {
+    @Id
+    private String team;
+    @Column
+    private String engName;
+    @Column
+    private String krName;
+    @Column
+    private String krFullName;
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/EplTeamRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/EplTeamRepository.java
@@ -1,0 +1,9 @@
+package KickIt.server.domain.teams.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EplTeamRepository extends JpaRepository<EplTeam, Long> {
+
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -1,6 +1,5 @@
 package KickIt.server.domain.teams.entity;
 
-import KickIt.server.domain.teams.EplTeams;
 import KickIt.server.domain.teams.PlayerPosition;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +17,7 @@ public class Player {
     // 선수 고유 id
     private UUID id;
     // 선수 소속팀
-    private EplTeams team;
+    private String team;
     // 선수 등번호
     // 선수 번호 데이터가 없는 경우 null 값 주므로 이를 수용하기 위해 int -> Integer로 변경
     private Integer number;

--- a/src/main/java/KickIt/server/domain/teams/entity/Squad.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Squad.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 // 각 팀별 선수 목록을 나타내기 위한 PlayerRepository
 public class Squad {
     // 팀 이름
-    private EplTeams team;
+    private String team;
     // 팀 로고 url
     private String logoImg;
     // 공격수(Forward) 선수 리스트

--- a/src/main/java/KickIt/server/domain/teams/service/EplTeamService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/EplTeamService.java
@@ -1,0 +1,29 @@
+package KickIt.server.domain.teams.service;
+
+import KickIt.server.domain.teams.dto.EplTeamDto;
+import KickIt.server.domain.teams.entity.EplTeam;
+import KickIt.server.domain.teams.entity.EplTeamRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class EplTeamService {
+    @Autowired
+    private EplTeamRepository eplTeamRepository;
+
+    // 전체 시즌 팀 이름 리스트 가지고 와 반환
+    @Transactional
+    public List<EplTeamDto.EplTeamResponse> FindAllEplTeams(){
+        List<EplTeam> eplTeamList = eplTeamRepository.findAll();
+        List<EplTeamDto.EplTeamResponse> responseList = new ArrayList<>();
+        for(EplTeam eplTeam: eplTeamList){
+            responseList.add(new EplTeamDto.EplTeamResponse(eplTeam));
+        }
+        return responseList;
+    }
+
+}

--- a/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
@@ -1,0 +1,27 @@
+package KickIt.server.domain.teams.service;
+
+import KickIt.server.domain.teams.dto.EplTeamDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TeamNameConvertService {
+    private final EplTeamService eplTeamService;
+    List<EplTeamDto.EplTeamResponse> responseList;
+
+    public TeamNameConvertService(EplTeamService eplTeamService){
+        this.eplTeamService = eplTeamService;
+        this.responseList = eplTeamService.FindAllEplTeams();
+    }
+
+    public String convertToKrName(String team){
+        String krName = responseList.stream()
+                .filter(eplTeam -> eplTeam.getTeam().equalsIgnoreCase(team))
+                .map(EplTeamDto.EplTeamResponse::getKrName)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        System.out.println(krName);
+        return krName;
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
@@ -1,6 +1,8 @@
 package KickIt.server.domain.teams.service;
 
 import KickIt.server.domain.teams.dto.EplTeamDto;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,8 +12,13 @@ public class TeamNameConvertService {
     private final EplTeamService eplTeamService;
     List<EplTeamDto.EplTeamResponse> responseList;
 
-    public TeamNameConvertService(EplTeamService eplTeamService){
+    @Autowired
+    public TeamNameConvertService(EplTeamService eplTeamService) {
         this.eplTeamService = eplTeamService;
+    }
+
+    @PostConstruct
+    public void init() {
         this.responseList = eplTeamService.FindAllEplTeams();
     }
 
@@ -21,7 +28,37 @@ public class TeamNameConvertService {
                 .map(EplTeamDto.EplTeamResponse::getKrName)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
-        System.out.println(krName);
+        //System.out.println(krName);
         return krName;
+    }
+
+    public String convertFromKrName(String krName){
+        String team = responseList.stream()
+                .filter(eplTeam -> eplTeam.getKrName().equalsIgnoreCase(krName))
+                .map(EplTeamDto.EplTeamResponse::getTeam)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        //System.out.println(team);
+        return team;
+    }
+
+    public String convertFromKrFullName(String krFullName){
+        String team = responseList.stream()
+                .filter(eplTeam -> eplTeam.getKrFullName().equalsIgnoreCase(krFullName))
+                .map(EplTeamDto.EplTeamResponse::getTeam)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        //System.out.println(team);
+        return team;
+    }
+
+    public String convertFromEngName(String engName){
+        String team = responseList.stream()
+                .filter(eplTeam -> eplTeam.getEngName().equalsIgnoreCase(engName))
+                .map(EplTeamDto.EplTeamResponse::getTeam)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        //System.out.println(team);
+        return team;
     }
 }

--- a/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/TeamNameConvertService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+// 시즌 전체 팀 이름 정보 DB에서 GET 해 오는 service 사용 -> 받아 온 리스트에서 이름 변환해 주는 service
 @Service
 public class TeamNameConvertService {
     private final EplTeamService eplTeamService;
@@ -22,43 +23,70 @@ public class TeamNameConvertService {
         this.responseList = eplTeamService.FindAllEplTeams();
     }
 
+
+    // 영어 이름 -> 한국어 이름
+    // TOT -> 토트넘
     public String convertToKrName(String team){
         String krName = responseList.stream()
                 .filter(eplTeam -> eplTeam.getTeam().equalsIgnoreCase(team))
                 .map(EplTeamDto.EplTeamResponse::getKrName)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
-        //System.out.println(krName);
         return krName;
     }
 
+    // 영어 이름 -> 한국어 풀네임
+    // TOT -> Tottenham Hotspur FC
+    public String convertToEngName(String team){
+        String engName = responseList.stream()
+                .filter(eplTeam -> eplTeam.getTeam().equalsIgnoreCase(team))
+                .map(EplTeamDto.EplTeamResponse::getEngName)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        return engName;
+    }
+
+    // 영어 이름 -> 영어 풀네임
+    // TOT -> 토트넘 홋스퍼 Fc
+    public String convertToKrFullName(String team){
+        String krFullName = responseList.stream()
+                .filter(eplTeam -> eplTeam.getTeam().equalsIgnoreCase(team))
+                .map(EplTeamDto.EplTeamResponse::getKrFullName)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
+        return krFullName;
+    }
+
+    // 한국어 이름 -> 영어 이름
+    // 토트넘 -> TOT
     public String convertFromKrName(String krName){
         String team = responseList.stream()
                 .filter(eplTeam -> eplTeam.getKrName().equalsIgnoreCase(krName))
                 .map(EplTeamDto.EplTeamResponse::getTeam)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
-        //System.out.println(team);
         return team;
     }
 
+    // 한국어 풀네임 -> 영어 이름
+    // 토트넘 홋스퍼 -> TOT
     public String convertFromKrFullName(String krFullName){
         String team = responseList.stream()
                 .filter(eplTeam -> eplTeam.getKrFullName().equalsIgnoreCase(krFullName))
                 .map(EplTeamDto.EplTeamResponse::getTeam)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
-        //System.out.println(team);
         return team;
     }
 
+    // 영어 풀네임 -> 영어 이름
+    // Tottenham Hotspur -> TOT
     public String convertFromEngName(String engName){
         String team = responseList.stream()
                 .filter(eplTeam -> eplTeam.getEngName().equalsIgnoreCase(engName))
                 .map(EplTeamDto.EplTeamResponse::getTeam)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("팀 이름을 찾을 수 없습니다."));
-        //System.out.println(team);
         return team;
     }
 }

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
 import java.sql.Timestamp;
@@ -22,8 +23,9 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Component
+
 // 경기 일정 정보 크롤링하는 FixtureCrawler
+@Component
 public class FixtureCrawler {
     @Autowired
     private TeamNameConvertService teamNameConvertService;

--- a/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/FixtureCrawler.java
@@ -2,11 +2,13 @@
 package KickIt.server.global.common.crawler;
 
 import KickIt.server.domain.fixture.entity.Fixture;
-import KickIt.server.domain.teams.EplTeams;
+import KickIt.server.domain.teams.service.TeamNameConvertService;
 import KickIt.server.global.util.WebDriverUtil;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 
 import java.sql.Timestamp;
@@ -20,8 +22,12 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@Component
 // 경기 일정 정보 크롤링하는 FixtureCrawler
 public class FixtureCrawler {
+    @Autowired
+    private TeamNameConvertService teamNameConvertService;
+
     // YYYY년 MM 월의 경기 일정 정보를 가져와 Fixture 객체 리스트로 반환하는 getFixture 함수
     public List<Fixture> getFixture(String year, String month) {
         WebDriver driver = WebDriverUtil.getChromeDriver();
@@ -55,7 +61,7 @@ public class FixtureCrawler {
                         // 각 팀의 정보를 포함하는 tr을 담은 list
                         List<WebElement> teams = getTeams(tr);
                         // 각 팀의 이름 EplTeams 배열로 저장
-                        EplTeams[] teamNames = getTeamNames(teams);
+                        String[] teamNames = getTeamNames(teams);
                         // 각 팀의 점수 배열로 저장
                         Integer[] teamScores = getTeamScores(teams);
                         // 한 경기의 경기 고유 id(생성), 시즌 정보, 날짜 및 시간, 홈팀 이름, 원정팀 이름,
@@ -134,10 +140,10 @@ public class FixtureCrawler {
 
     // 경기에 참여하는 두 팀의 이름을 담은 배열을 반환하는 함수 getTeamNames
     // 0 번 요소가 홈팀, 1 번 요소가 원정팀
-    EplTeams[] getTeamNames(List<WebElement> row) {
+    String[] getTeamNames(List<WebElement> row) {
         String homeTeamName = row.get(0).findElement(By.className("txt_team")).getText();
         String awayTeamName = row.get(1).findElement(By.className("txt_team")).getText();
-        return new EplTeams[]{EplTeams.valueOfKrName(homeTeamName), EplTeams.valueOfKrName(awayTeamName)};
+        return new String[]{teamNameConvertService.convertFromKrName(homeTeamName), teamNameConvertService.convertFromKrName(awayTeamName)};
     }
 
     // 경기에 참여하는 두 팀의 점수를 담은 배열을 반환하는 함수 getTeamScores

--- a/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/LineupCrawler.java
@@ -3,7 +3,6 @@ package KickIt.server.global.common.crawler;
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.lineup.entity.MatchLineup;
 import KickIt.server.domain.lineup.entity.TeamLineup;
-import KickIt.server.domain.teams.EplTeams;
 import KickIt.server.domain.teams.entity.Player;
 import KickIt.server.global.util.WebDriverUtil;
 import org.openqa.selenium.By;
@@ -140,7 +139,7 @@ public class LineupCrawler {
     }
 
     // 매개변수로 주어진 WebElement에서 선수 리스트를 가져오는 함수
-    ArrayList<Player> getPlayers(WebElement element, EplTeams teamName){
+    ArrayList<Player> getPlayers(WebElement element, String teamName){
         // 반환할 Player 객체 리스트 생성
         ArrayList<Player> players = new ArrayList<>();
         // 주어진 매개변수 Element에서 선수 명단이 있는 Element 찾아 가져옴
@@ -159,7 +158,7 @@ public class LineupCrawler {
     }
 
     // 매개변수로 주어진 WebElement에서 후보 선수 리스트를 가져오는 함수
-    ArrayList<Player> getBenchPlayers(List<WebElement> elements, EplTeams teamName){
+    ArrayList<Player> getBenchPlayers(List<WebElement> elements, String teamName){
         // 반환할 Player 객체 리스트 생성
         ArrayList<Player> benchPlayers = new ArrayList<>();
         for(int i = 0; i < elements.size(); i++) {

--- a/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/SquadCrawler.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 
 import java.time.Duration;
@@ -19,6 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 // 현재 시즌의 팀별 선수 명단을 크롤링하기 위한 SquadCrawler
+@Component
 public class SquadCrawler {
     @Autowired
     private TeamNameConvertService teamNameConvertService;

--- a/src/main/java/KickIt/server/global/common/crawler/test.java
+++ b/src/main/java/KickIt/server/global/common/crawler/test.java
@@ -1,17 +1,25 @@
 package KickIt.server.global.common.crawler;
 
+import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.teams.entity.Teaminfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@Component
 public class test {
+    @Autowired
+    public static FixtureCrawler mayFixtureCrawler;
 
     public static void main(String[] args) {
         /*
         // fixtureCrawler 테스트 및 출력
-        FixtureCrawler mayFixtureCrawler = new FixtureCrawler();
         String year = String.valueOf(LocalDate.now().getYear());
         //String month = String.format("%02d", LocalDate.now().getMonthValue());
         String month = "05";


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #37 
<br>
closed jira #77

## ✨ 변경 사항 및 이유
기존에 23-24 시즌 팀만 enum 형태로 팀 이름 처리했던 로직 변경, DB에 팀 이름 데이터 저장해 두고 조회해 오는 service 제작해 전체 코드 내에서  사용할 수 있도록 보수했음.
- 시즌 팀 정보 Entity, 모든 시즌 팀 이름 전체 조회 GET API 추가
- 팀 이름 변경해 주는 service 추가
- 전체 코드에 해당 사항 적용 및 수정 

