### PR TITLE
🎉 Feat: 시즌별 각 팀 선수 명단, 선수 정보 entity, post api 개발

### DIFF
--- a/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
@@ -1,0 +1,38 @@
+package KickIt.server.domain.teams.controller;
+
+import KickIt.server.domain.teams.entity.Squad;
+import KickIt.server.domain.teams.service.SquadService;
+import KickIt.server.global.common.crawler.FixtureCrawler;
+import KickIt.server.global.common.crawler.SquadCrawler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/squad")
+public class SquadController {
+    @Autowired
+    SquadService squadService;
+    @Autowired
+    SquadCrawler squadCrawler;
+
+    @PostMapping("/crawl")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<Map<String, Object>> crawlSquad(@RequestParam("season") String season){
+        List<Squad> squadList = new ArrayList<>();
+        squadList = squadCrawler.getTeamSquads(season);
+
+        squadService.saveSquads(squadList);
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", HttpStatus.OK.value());
+        responseBody.put("message", "success");
+        responseBody.put("data", squadList);
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/dto/SquadDto.java
+++ b/src/main/java/KickIt/server/domain/teams/dto/SquadDto.java
@@ -1,0 +1,60 @@
+package KickIt.server.domain.teams.dto;
+
+import KickIt.server.domain.teams.entity.Player;
+import KickIt.server.domain.teams.entity.Squad;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SquadDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SquadRequest{
+        private String season;
+        private String team;
+        private String logoImg;
+        private List<Player> FWplayers;
+        private List<Player> MFplayers;
+        private List<Player> DFplayers;
+        private List<Player> GKplayers;
+
+        public Squad toEntity(){
+            Squad squad = Squad.builder()
+                    .season(this.season)
+                    .team(this.team)
+                    .logoImg(this.logoImg)
+                    .FWplayers(this.FWplayers)
+                    .MFplayers(this.MFplayers)
+                    .DFplayers(this.DFplayers)
+                    .GKplayers(this.GKplayers)
+                    .build();
+            return squad;
+        }
+    }
+
+    @Getter
+    public static class SquadResponse{
+        private Long id;
+        private String season;
+        private String team;
+        private String logoImg;
+        private List<Player> FWplayers;
+        private List<Player> MFplayers;
+        private List<Player> DFplayers;
+        private List<Player> GKplayers;
+
+        public SquadResponse(Squad squad){
+            this.id = squad.getId();
+            this.season = squad.getSeason();
+            this.team = squad.getTeam();
+            this.logoImg = squad.getLogoImg();
+            this.FWplayers = squad.getFWplayers();
+            this.MFplayers = squad.getMFplayers();
+            this.DFplayers = squad.getDFplayers();
+            this.GKplayers = squad.getGKplayers();
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -1,6 +1,7 @@
 package KickIt.server.domain.teams.entity;
 
 import KickIt.server.domain.teams.PlayerPosition;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,6 +38,7 @@ public class Player {
 
     @ManyToOne
     @JoinColumn(name = "squad_id")
+    @JsonBackReference
     private Squad squad;
 
     // Squad를 설정하는 메소드

--- a/src/main/java/KickIt/server/domain/teams/entity/Player.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Player.java
@@ -1,20 +1,25 @@
 package KickIt.server.domain.teams.entity;
 
 import KickIt.server.domain.teams.PlayerPosition;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
 
 // 한 선수의 정보를 담을 class Player
+@Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Player {
     // 선수 고유 id
+    @Id
     private UUID id;
     // 선수 소속팀
     private String team;
@@ -24,7 +29,18 @@ public class Player {
     // 선수 이름
     private String name;
     // 선수 포지션
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
     private PlayerPosition position;
     // 이미지 주소
     private String profileImg;
+
+    @ManyToOne
+    @JoinColumn(name = "squad_id")
+    private Squad squad;
+
+    // Squad를 설정하는 메소드
+    public void assignSquad(Squad squad) {
+        this.squad = squad;
+    }
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/Squad.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Squad.java
@@ -1,28 +1,72 @@
 package KickIt.server.domain.teams.entity;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
+import java.util.List;
 
+@Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 // 각 팀별 선수 목록을 나타내기 위한 PlayerRepository
 public class Squad {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    // 시즌
+    private String season;
     // 팀 이름
     private String team;
     // 팀 로고 url
     private String logoImg;
     // 공격수(Forward) 선수 리스트
-    private ArrayList<Player> FWplayers;
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    private List<Player> FWplayers;
     // 미드필더(Midfielder) 선수 리스트
-    private ArrayList<Player> MFplayers;
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    private List<Player> MFplayers;
     // 수비수(Defender) 선수 리스트
-    private ArrayList<Player> DFplayers;
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    private List<Player> DFplayers;
     // 골키퍼(Goalkeeper) 선수 리스트
-    private ArrayList<Player> GKplayers;
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    private List<Player> GKplayers;
+
+    // FW Player 추가 및 양방향 관계 설정
+    public void addFWPlayers(List<Player> players) {
+        this.FWplayers = players;
+        for(Player player : players){
+            player.assignSquad(this);
+        }
+    }
+
+    // MF Player 추가 및 양방향 관계 설정
+    public void addMFPlayers(List<Player> players) {
+        this.MFplayers = players;
+        for(Player player : players){
+            player.assignSquad(this);
+        }
+    }
+
+    // DF Player 추가 및 양방향 관계 설정
+    public void addDFPlayers(List<Player> players) {
+        this.DFplayers = players;
+        for(Player player : players){
+            player.assignSquad(this);
+        }
+    }
+
+    // GK Player 추가 및 양방향 관계 설정
+    public void addGKPlayers(List<Player> players) {
+        this.GKplayers = players;
+        for(Player player : players){
+            player.assignSquad(this);
+        }
+    }
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/Squad.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Squad.java
@@ -1,5 +1,6 @@
 package KickIt.server.domain.teams.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,15 +28,19 @@ public class Squad {
     private String logoImg;
     // 공격수(Forward) 선수 리스트
     @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @JsonManagedReference
     private List<Player> FWplayers;
     // 미드필더(Midfielder) 선수 리스트
     @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @JsonManagedReference
     private List<Player> MFplayers;
     // 수비수(Defender) 선수 리스트
     @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @JsonManagedReference
     private List<Player> DFplayers;
     // 골키퍼(Goalkeeper) 선수 리스트
     @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @JsonManagedReference
     private List<Player> GKplayers;
 
     // FW Player 추가 및 양방향 관계 설정

--- a/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
@@ -1,0 +1,9 @@
+package KickIt.server.domain.teams.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SquadRepository extends JpaRepository<Squad, Long>{
+    Optional<Squad> findBySeasonAndTeam(String season, String team);
+}

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -1,0 +1,42 @@
+package KickIt.server.domain.teams.service;
+
+import KickIt.server.domain.teams.dto.SquadDto;
+import KickIt.server.domain.teams.entity.Squad;
+import KickIt.server.domain.teams.entity.SquadRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SquadService {
+    @Autowired
+    private SquadRepository squadRepository;
+
+    @Transactional
+    public void saveSquads(List<Squad> squadList){
+        for(Squad squad : squadList){
+            Optional<Squad> existingSquad = squadRepository.findBySeasonAndTeam(squad.getSeason(), squad.getTeam());
+            // 만약 이미 해당 팀 / 해당 시즌의 선수 목록 존재하는 경우 업데이트
+            if(existingSquad.isPresent()){
+                Squad updatedSquad = Squad.builder()
+                        .id(existingSquad.get().getId())
+                        .season(squad.getSeason())
+                        .team(squad.getTeam())
+                        .logoImg(squad.getLogoImg())
+                        .FWplayers(squad.getFWplayers())
+                        .MFplayers(squad.getMFplayers())
+                        .DFplayers(squad.getDFplayers())
+                        .GKplayers(squad.getGKplayers())
+                        .build();
+                squadRepository.save(squad);
+            }
+            // 아닌 경우 새로 저장
+            else{
+                squadRepository.save(squad);
+            }
+        }
+    }
+}


### PR DESCRIPTION

## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #40 
<br>
closed jira #81

## ✨ 변경 사항 및 이유
기존의 squadCrawler를 통한 크롤링으로 가져오는 시즌별 팀별 선수 명단 정보와 각 선수의 정보를 일대다 관계로 조인해 DB에 저장하도록 entity 수정 및 DTO, Repository, Service 생성, POST API 개발 