### PR TITLE
🔧 Fix: post API 호출 후 중복 저장하는 오류 선수 update만 하도록 수정

### DIFF
--- a/src/main/java/KickIt/server/domain/teams/entity/Squad.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Squad.java
@@ -27,19 +27,19 @@ public class Squad {
     // 팀 로고 url
     private String logoImg;
     // 공격수(Forward) 선수 리스트
-    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Player> FWplayers;
     // 미드필더(Midfielder) 선수 리스트
-    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Player> MFplayers;
     // 수비수(Defender) 선수 리스트
-    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Player> DFplayers;
     // 골키퍼(Goalkeeper) 선수 리스트
-    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "squad", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Player> GKplayers;
 

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -26,12 +26,12 @@ public class SquadService {
                         .season(squad.getSeason())
                         .team(squad.getTeam())
                         .logoImg(squad.getLogoImg())
-                        .FWplayers(squad.getFWplayers())
-                        .MFplayers(squad.getMFplayers())
-                        .DFplayers(squad.getDFplayers())
-                        .GKplayers(squad.getGKplayers())
                         .build();
-                squadRepository.save(squad);
+                updatedSquad.addFWPlayers(squad.getFWplayers());
+                updatedSquad.addMFPlayers(squad.getMFplayers());
+                updatedSquad.addDFPlayers(squad.getDFplayers());
+                updatedSquad.addGKPlayers(squad.getGKplayers());
+                squadRepository.save(updatedSquad);
             }
             // 아닌 경우 새로 저장
             else{


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #40 
<br>
closed jira #81

## ✨ 변경 사항 및 이유
POST API 호출 시 팀과 시즌으로 중복 데이터가 있는지 검사하는 로직은 있었으나, 데이터 테이블에 저장할 때 같은 팀과 선수들이 중복으로 생성되게 되는 이슈 있었음. 이를 선수 명단만 업데이트 하고, 새로운 팀을 생성하지는 않도록 변경함.
