### PR TITLE
🎉 Feat: API 명세서 변경에 따른 홈팀, 원정팀 로고 이미지 Url 정보 필드 추가

### DIFF
--- a/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
+++ b/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
@@ -79,7 +79,7 @@ public class FixtureController {
     @GetMapping("/dates")
     public ResponseEntity<Map<String, Object>> getFixturesByMonth(@RequestParam("yearMonth") @DateTimeFormat(pattern = "yyyy/MM") Date yearMonth, @RequestParam(value="teamName", required = false) String teamName){
         Map<String, Object> responseBody = new HashMap<>();
-        List<FixtureDto.FixtureDateResponse> responseList;
+        FixtureDto.FixtureDateResponse response;
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(yearMonth);
         int year = calendar.get(Calendar.YEAR);
@@ -87,7 +87,7 @@ public class FixtureController {
 
         // teamName이 입력되지 않은 경우 월만으로 경기 조회
         if(teamName == null){
-            responseList = fixtureService.findFixturesByMonth(year, month);
+            response = fixtureService.findFixturesByMonth(year, month);
             // 입력된 teamName으로 EplTeam이 찾아지지 않는 경우 Bad Request 처리
         }
         // teamName이 입력된 경우 날짜와 팀으로 경기 조회
@@ -98,13 +98,13 @@ public class FixtureController {
                 responseBody.put("message", "팀 이름 입력 오류");
                 return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
             }
-            responseList = fixtureService.findFixtureByMonthAndTeam(year, month, team);
+            response = fixtureService.findFixtureByMonthAndTeam(year, month, team);
         }
         // 조회해 가져온 데이터가 존재하는 경우 성공, OK status로 반환
-        if(!responseList.isEmpty()){
+        if(response != null){
             responseBody.put("status", HttpStatus.OK.value());
             responseBody.put("message", "success");
-            responseBody.put("data", responseList);
+            responseBody.put("data", response);
             return new ResponseEntity<>(responseBody, HttpStatus.OK);
         }
         // 조회한 list가 비어있는 경우 데이터 없음 처리, NOT FOUND로 반환

--- a/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
+++ b/src/main/java/KickIt/server/domain/fixture/controller/FixtureController.java
@@ -114,4 +114,20 @@ public class FixtureController {
             return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
         }
     }
+
+    @PatchMapping("/editScore")
+    public ResponseEntity<Map<String, Object>> editFixtureScore(@RequestParam("fixtureId") Long fixtureId, @RequestParam("homeTeamScore") Integer homeTeamScore, @RequestParam("awayTeamScore") Integer awayTeamScore){
+        Boolean isSuccess = fixtureService.updateFixtureScore(fixtureId, homeTeamScore, awayTeamScore);
+        Map<String, Object> responseBody = new HashMap<>();
+        if(isSuccess){
+            responseBody.put("status", HttpStatus.OK.value());
+            responseBody.put("message", "success");
+            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        }
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "찾는 경기 없음");
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -1,6 +1,7 @@
 package KickIt.server.domain.fixture.dto;
 
 import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.teams.service.SquadService;
 import KickIt.server.domain.teams.service.TeamNameConvertService;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +10,7 @@ import org.springframework.stereotype.Component;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
-import java.util.UUID;
+import java.util.*;
 
 @Component
 public class FixtureDto {
@@ -21,6 +20,9 @@ public class FixtureDto {
     public FixtureDto(TeamNameConvertService teamNameConvertService) {
         this.teamNameConvertService = teamNameConvertService;
     }
+
+    @Autowired
+    private SquadService squadService;
 
     @Data
     @AllArgsConstructor
@@ -92,15 +94,26 @@ public class FixtureDto {
         }
     }
 
+    // 한달 경기 일정 정보 조회 response class
+    // soccerTeamNames 항목 유무 매개변수로 받아옴 (해당 API 호출 시 팀 네임 함께 입력되었는지 여부)
     @Getter
-    public static class FixtureDateResponse{
-        private String date;
+    public class FixtureDateResponse{
+        private String soccerSeason;
+        private List<String> matchDates;
+        private List<String> soccerTeamNames;
 
-        // entity to dto
-        public FixtureDateResponse(Fixture fixture){
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd");
-            sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
-            this.date = sdf.format(new Date(fixture.getDate().getTime()));
+        public FixtureDateResponse(List<Fixture> fixtures, Boolean isTeamNameExist){
+            matchDates = new ArrayList<>();
+            for (Fixture fixture: fixtures){
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd");
+                sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
+                this.matchDates.add(sdf.format(new Date(fixture.getDate().getTime())));
+            }
+            soccerSeason = fixtures.get(0).getSeason();
+            if(!isTeamNameExist){
+                soccerTeamNames = squadService.getSeasonSquads(soccerSeason);
+            }
         }
     }
+
 }

--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -67,6 +67,8 @@ public class FixtureDto {
         private String season;
         private String dateStr;
         private String timeStr;
+        private String homeTeamEmblemUrl;
+        private String awayTeamEmblemUrl;
         private String homeTeam;
         private String awayTeam;
         private Integer homeTeamScore;
@@ -83,7 +85,8 @@ public class FixtureDto {
             // 가져온 Date를 yyyy-MM-dd와 HH:mm 두 개로 나누어 문자열로 반환
             this.dateStr = new SimpleDateFormat("yyyy-MM-dd").format(fixture.getDate());
             this.timeStr = new SimpleDateFormat("HH:mm").format(fixture.getDate());
-
+            this.homeTeamEmblemUrl = squadService.getTeamLogoImg(fixture.getSeason(), fixture.getHomeTeam());
+            this.awayTeamEmblemUrl = squadService.getTeamLogoImg(fixture.getSeason(), fixture.getAwayTeam());
             this.homeTeam = teamNameConvertService.convertToKrName(fixture.getHomeTeam());
             this.awayTeam = teamNameConvertService.convertToKrName(fixture.getAwayTeam());
             this.homeTeamScore = fixture.getHomeTeamScore();

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -69,23 +69,23 @@ public class FixtureService {
 
     // findByMonth로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
-    public List<FixtureDto.FixtureDateResponse> findFixturesByMonth(int year, int month){
+    public FixtureDto.FixtureDateResponse findFixturesByMonth(int year, int month){
         List<Fixture> fixtureList = fixtureRepository.findByMonth(year, month);
-        List<FixtureDto.FixtureDateResponse> responseList = new ArrayList<>();
-        for (Fixture fixture: fixtureList){
-            responseList.add(new FixtureDto.FixtureDateResponse(fixture));
+        if(fixtureList.isEmpty()){
+            return null;
         }
-        return responseList;
+        FixtureDto.FixtureDateResponse response = fixtureDto.new FixtureDateResponse(fixtureList, false);
+        return response;
     }
 
     // findByMonthAndTeam으로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
-    public List<FixtureDto.FixtureDateResponse> findFixtureByMonthAndTeam(int year, int month, String team){
+    public FixtureDto.FixtureDateResponse findFixtureByMonthAndTeam(int year, int month, String team){
         List<Fixture> fixtureList = fixtureRepository.findByMonthAndTeam(year, month, team);
-        List<FixtureDto.FixtureDateResponse> responseList = new ArrayList<>();
-        for (Fixture fixture: fixtureList){
-            responseList.add(new FixtureDto.FixtureDateResponse(fixture));
+        if(fixtureList.isEmpty()){
+            return null;
         }
-        return responseList;
+        FixtureDto.FixtureDateResponse response = fixtureDto.new FixtureDateResponse(fixtureList, true);
+        return response;
     }
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -11,6 +11,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class FixtureService {
@@ -87,5 +88,29 @@ public class FixtureService {
         }
         FixtureDto.FixtureDateResponse response = fixtureDto.new FixtureDateResponse(fixtureList, true);
         return response;
+    }
+
+    @Transactional
+    public boolean updateFixtureScore(Long fixtureId, Integer homeTeamScore, Integer awayTeamScore){
+        Optional<Fixture> fixture = fixtureRepository.findById(fixtureId);
+        if(fixture.isPresent()){
+            Fixture updatedFixture = Fixture.builder()
+                    .id(fixtureId)
+                    .season(fixture.get().getSeason())
+                    .date(fixture.get().getDate())
+                    .homeTeam(fixture.get().getHomeTeam())
+                    .awayTeam(fixture.get().getAwayTeam())
+                    .homeTeamScore(homeTeamScore)
+                    .awayteamScore(awayTeamScore)
+                    .round(fixture.get().getRound())
+                    .status(fixture.get().getStatus())
+                    .stadium(fixture.get().getStadium())
+                    .lineupUrl(fixture.get().getLineupUrl()).build();
+            fixtureRepository.save(updatedFixture);
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
@@ -3,9 +3,11 @@ package KickIt.server.domain.teams.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SquadRepository extends JpaRepository<Squad, Long>{
     Optional<Squad> findBySeasonAndTeam(String season, String team);
+    List<Squad> findBySeason(String season);
 }

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -53,4 +53,13 @@ public class SquadService {
         }
         return squadNames;
     }
+
+    @Transactional
+    public String getTeamLogoImg(String season, String team){
+        Optional<Squad> squad = squadRepository.findBySeasonAndTeam(season, team);
+        if(squad.isPresent()){
+            return squad.get().getLogoImg();
+        }
+        return null;
+    }
 }

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,8 @@ import java.util.Optional;
 public class SquadService {
     @Autowired
     private SquadRepository squadRepository;
+    @Autowired
+    private TeamNameConvertService teamNameConvertService;
 
     @Transactional
     public void saveSquads(List<Squad> squadList){
@@ -38,5 +41,16 @@ public class SquadService {
                 squadRepository.save(squad);
             }
         }
+    }
+
+    // 해당 시즌 팀 이름만을 반환
+    @Transactional
+    public List<String> getSeasonSquads(String season){
+        List<Squad> seasonSquads = squadRepository.findBySeason(season);
+        List<String> squadNames = new ArrayList<>();
+        for(Squad squad : seasonSquads){
+            squadNames.add(teamNameConvertService.convertToKrName(squad.getTeam()));
+        }
+        return squadNames;
     }
 }


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #57
closed jira #108

## ✨ 변경 사항 및 이유
하루 경기 일정 조회 API 명세서 변경에 따른 GET API 내부 홈팀, 원정팀 로고 이미지 Url 정보 필드 추가
경기 타임라인 크롤링 후 최종 점수 저장을 위해 사용할 경기 점수 변경 API / service 개발

