### PR TITLE
🎉 Feat: 우승팀 예측 POST API 개발 

### DIFF
--- a/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
@@ -1,13 +1,12 @@
-package KickIt.server.domain.lineup.controller;
+package KickIt.server.domain.lineupPrediction.controller;
 
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.fixture.entity.FixtureRepository;
-import KickIt.server.domain.lineup.dto.LineupPredictionDto;
-import KickIt.server.domain.lineup.entity.LineupPrediction;
-import KickIt.server.domain.lineup.entity.LineupPredictionRepository;
-import KickIt.server.domain.lineup.entity.PredictionPlayer;
-import KickIt.server.domain.lineup.service.LineupPredictionService;
-import KickIt.server.domain.member.dto.MemberRepository;
+import KickIt.server.domain.lineupPrediction.dto.LineupPredictionDto;
+import KickIt.server.domain.lineupPrediction.entity.LineupPrediction;
+import KickIt.server.domain.lineupPrediction.entity.PredictionPlayer;
+import KickIt.server.domain.lineupPrediction.service.LineupPredictionService;
+import KickIt.server.domain.member.entity.MemberRepository;
 import KickIt.server.domain.member.entity.Member;
 import KickIt.server.domain.member.service.MemberService;
 import KickIt.server.domain.teams.entity.Player;

--- a/src/main/java/KickIt/server/domain/lineupPrediction/dto/LineupPredictionDto.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/dto/LineupPredictionDto.java
@@ -1,9 +1,6 @@
-package KickIt.server.domain.lineup.dto;
+package KickIt.server.domain.lineupPrediction.dto;
 
 import KickIt.server.domain.fixture.dto.ResponsePlayerInfo;
-import KickIt.server.domain.lineup.entity.LineupPrediction;
-import KickIt.server.domain.lineup.entity.LineupPredictionRepository;
-import KickIt.server.domain.lineup.entity.PredictionPlayer;
 import KickIt.server.domain.member.entity.Member;
 import KickIt.server.domain.teams.PlayerPosition;
 import KickIt.server.domain.teams.entity.Player;
@@ -11,10 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 
 // 선발 라인업 예측 DTO

--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPrediction.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPrediction.java
@@ -1,4 +1,4 @@
-package KickIt.server.domain.lineup.entity;
+package KickIt.server.domain.lineupPrediction.entity;
 
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.member.entity.Member;

--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionId.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionId.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 // LineupPrediction Entity class의 복합 키(경기 id + 사용자 id) 사용을 위한 클래스
+// ScorePrediction Entity에도 사용
 public class LineupPredictionId implements Serializable {
     private Long member;  // member_id
     private Long fixture;   // fixture_id

--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionId.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionId.java
@@ -1,4 +1,4 @@
-package KickIt.server.domain.lineup.entity;
+package KickIt.server.domain.lineupPrediction.entity;
 
 import java.io.Serializable;
 import java.util.Objects;

--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionRepository.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionRepository.java
@@ -1,6 +1,5 @@
-package KickIt.server.domain.lineup.entity;
+package KickIt.server.domain.lineupPrediction.entity;
 
-import KickIt.server.domain.lineup.dto.LineupPredictionDto;
 import KickIt.server.domain.teams.entity.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,7 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface LineupPredictionRepository extends JpaRepository<LineupPrediction, Long> {
     @Query("SELECT l FROM LineupPrediction l WHERE l.member.id = :memberId AND l.fixture.id = :fixtureId")

--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/PredictionPlayer.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/PredictionPlayer.java
@@ -1,4 +1,4 @@
-package KickIt.server.domain.lineup.entity;
+package KickIt.server.domain.lineupPrediction.entity;
 
 import KickIt.server.domain.teams.entity.Player;
 import jakarta.persistence.*;

--- a/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
@@ -1,9 +1,12 @@
-package KickIt.server.domain.lineup.service;
+package KickIt.server.domain.lineupPrediction.service;
 
 import KickIt.server.domain.fixture.dto.ResponsePlayerInfo;
-import KickIt.server.domain.lineup.dto.LineupPredictionDto;
+import KickIt.server.domain.lineup.service.MatchLineupService;
+import KickIt.server.domain.lineupPrediction.dto.LineupPredictionDto;
 import KickIt.server.domain.lineup.dto.MatchLineupDto;
-import KickIt.server.domain.lineup.entity.*;
+import KickIt.server.domain.lineupPrediction.entity.LineupPrediction;
+import KickIt.server.domain.lineupPrediction.entity.LineupPredictionRepository;
+import KickIt.server.domain.lineupPrediction.entity.PredictionPlayer;
 import KickIt.server.domain.teams.entity.Player;
 import KickIt.server.domain.teams.entity.SquadRepository;
 import jakarta.transaction.Transactional;

--- a/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
@@ -1,0 +1,93 @@
+package KickIt.server.domain.scorePrediction.controller;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.fixture.entity.FixtureRepository;
+import KickIt.server.domain.member.entity.Member;
+import KickIt.server.domain.member.entity.MemberRepository;
+import KickIt.server.domain.member.service.MemberService;
+import KickIt.server.domain.scorePrediction.dto.ScorePredictionDto;
+import KickIt.server.domain.scorePrediction.entity.ScorePrediction;
+import KickIt.server.domain.scorePrediction.service.ScorePredictionService;
+import KickIt.server.jwt.JwtTokenUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/score-predict")
+public class ScorePredictionController {
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    FixtureRepository fixtureRepository;
+    @Autowired
+    ScorePredictionService scorePredictionService;
+
+    @PostMapping("/save")
+    public ResponseEntity<Map<String, Object>> saveScorePrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
+        // 반환할 responseBody
+        Map<String, Object> responseBody = new HashMap<>();
+        // member를 찾기 위해 token으로 email 조회
+        String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
+        // 찾은 email로 member 조회
+        Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
+
+        // 입력된 token의 email로 찾은 member가 존재하는 경우
+        if(foundMember != null){
+            // 경기 id로 경기 조회
+            Fixture foundFixture = fixtureRepository.findById(matchId).orElse(null);
+            // 경기 id로 조회한 경기가 존재하는 경우
+            if(foundFixture != null){
+                ScorePrediction scorePrediction = ScorePrediction.builder()
+                        .member(foundMember)
+                        .fixture(foundFixture)
+                        .homeTeamScore(scorePredictionSaveRequest.getHomeTeamScore())
+                        .awayTeamScore(scorePredictionSaveRequest.getAwayTeamScore())
+                        .build();
+                HttpStatus saveStatus = scorePredictionService.saveScorePrediction(scorePrediction);
+                if(saveStatus == HttpStatus.OK) {
+                    ScorePredictionDto.ScorePredictionSaveResponse response = new ScorePredictionDto.ScorePredictionSaveResponse(foundMember);
+                    responseBody.put("status", HttpStatus.OK.value());
+                    responseBody.put("message", "success");
+                    responseBody.put("data", response);
+                    responseBody.put("isSuccess", false);
+                    return new ResponseEntity<>(responseBody, HttpStatus.OK);
+                }
+                else if(saveStatus == HttpStatus.CONFLICT){
+                    responseBody.put("status", saveStatus);
+                    responseBody.put("message", "중복 저장 시도");
+                    responseBody.put("isSuccess", false);
+                    return new ResponseEntity<>(responseBody, HttpStatus.CONFLICT);
+                }
+                else {
+                    responseBody.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    responseBody.put("message", "저장 실패");
+                    responseBody.put("isSuccess", false);
+                    return new ResponseEntity<>(responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+            // 경기 id로 조회한 경기가 존재하지 않는 경우
+            else{
+                responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                responseBody.put("message", "해당 경기 없음");
+                responseBody.put("isSuccess", false);
+                return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            }
+        }
+        // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "해당 사용자 없음");
+            responseBody.put("isSuccess", false);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/scorePrediction/dto/ScorePredictionDto.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/dto/ScorePredictionDto.java
@@ -1,0 +1,37 @@
+package KickIt.server.domain.scorePrediction.dto;
+
+import KickIt.server.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class ScorePredictionDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 우승팀 예측 저장 Request
+    public static class ScorePredictionSaveRequest{
+        // 사용자가 예측한 홈팀 득점 점수
+        int homeTeamScore;
+        // 사용자가 예측한 원정팀 득점 점수
+        int awayTeamScore;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 우승팀 예측 저장 Response
+    public static class ScorePredictionSaveResponse{
+        // 사용자 등급
+        int grade;
+        // 사용자가 현재까지 획득한 포인트
+        int point;
+        public ScorePredictionSaveResponse(Member member){
+            this.grade = member.getGrade();
+            this.point = member.getPoint();
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePrediction.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePrediction.java
@@ -1,0 +1,35 @@
+package KickIt.server.domain.scorePrediction.entity;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.lineupPrediction.entity.LineupPredictionId;
+import KickIt.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(LineupPredictionId.class)
+// 우승팀 예측하기 과업의 사용자 예측 데이터 entity
+public class ScorePrediction {
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "fixture_id", nullable = false)
+    // 경기 정보
+    Fixture fixture;
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    // 사용자 정보
+    Member member;
+
+    // 사용자가 예측한 홈팀 점수
+    Integer homeTeamScore;
+    // 사용자가 예측한 원정팀 점수
+    Integer awayTeamScore;
+}

--- a/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePredictionRepository.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePredictionRepository.java
@@ -1,0 +1,12 @@
+package KickIt.server.domain.scorePrediction.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ScorePredictionRepository extends JpaRepository<ScorePrediction, Long> {
+    @Query("SELECT s FROM ScorePrediction s WHERE s.fixture.id = :fixtureId AND s.member.id = :memberId")
+    Optional<ScorePrediction> findByFixtureAndMember(@Param("fixtureId") Long fixtureId, @Param("memberId") Long memberId);
+}

--- a/src/main/java/KickIt/server/domain/scorePrediction/service/ScorePredictionService.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/service/ScorePredictionService.java
@@ -1,0 +1,33 @@
+package KickIt.server.domain.scorePrediction.service;
+
+import KickIt.server.domain.scorePrediction.entity.ScorePrediction;
+import KickIt.server.domain.scorePrediction.entity.ScorePredictionRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScorePredictionService {
+    @Autowired
+    ScorePredictionRepository scorePredictionRepository;
+
+    @Transactional
+    public HttpStatus saveScorePrediction(ScorePrediction scorePrediction){
+        // 중복 저장인지 확인하기 위해 사용자의 id와 경기 id로 DB에서 scorePrediction 데이터 조회
+        ScorePrediction foundScorePrediction = scorePredictionRepository.findByFixtureAndMember(scorePrediction.getFixture().getId(), scorePrediction.getMember().getId()).orElse(null);
+        // 새로 저장하는 데이터인 경우 -> 저장 진행
+        if(foundScorePrediction == null){
+            // 저장 시도
+            try {
+                scorePredictionRepository.save(scorePrediction);
+            }
+            // 실패 시 false 반환
+            catch (Exception e) { return HttpStatus.INTERNAL_SERVER_ERROR; }
+            // 성공 시 true 반환
+            finally { return HttpStatus.OK; }
+        }
+        // 이미 저장된 데이터가 있는 경우 -> 저장 과정 없이 false 반환
+        else{ return HttpStatus.CONFLICT; }
+    }
+}


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #71 
<br>
closed jira #119

## ✨ 변경 사항 및 이유
- 우승팀 예측 관련 entity, dto, controller, service 제작
- 우승팀 예측 POST API 개발
  -  xAuthToken 틀리게 입력했을 때 오류 처리
  - matchId 없는 경기로 입력했을 때 오류 처리
  - 이미 예측 데이터 있는 경우 중복 저장으로 오류 처리