### PR TITLE
🎉 Feat: 경기 예측 조회 GET API

### DIFF
--- a/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionRepository.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/entity/LineupPredictionRepository.java
@@ -29,4 +29,10 @@ public interface LineupPredictionRepository extends JpaRepository<LineupPredicti
 
     @Query(value = "SELECT p.player, COUNT(p.player.id) As count FROM LineupPrediction l JOIN l.players p WHERE l.fixture.id = :fixtureId and l.awayTeamForm = :awayFormation AND p.team = 1 AND p.position = :position AND p.location = :location GROUP BY p.player.id ORDER BY count DESC, p.player.number ASC LIMIT 1")
     Player findAvgAwayPlayer(@Param("fixtureId") Long fixtureId, @Param("awayFormation") Integer awayFormation, @Param("position") Integer position, @Param("location") Integer location);
+
+    @Query(value = "SELECT COUNT(l) FROM LineupPrediction l WHERE l.fixture.id = :fixtureId AND l.homeTeamForm = :avgHomeFormation")
+    Integer findAvgHomeTeamFormParticipant(@Param("fixtureId") Long fixtureId, @Param("avgHomeFormation") Integer avgHomeFormation);
+
+    @Query(value = "SELECT COUNT(l) FROM LineupPrediction l WHERE l.fixture.id = :fixtureId AND l.awayTeamForm = :avgAwayFormation")
+    Integer findAvgAwayTeamFormParticipant(@Param("fixtureId") Long fixtureId, @Param("avgAwayFormation") Integer avgAwayFormation);
 }

--- a/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
@@ -118,7 +118,7 @@ public class LineupPredictionService {
 
     // 사용자와 평균 선발라인업 예측이 정확한지 확인 후 반환
     // 이미 선발 라인업 결과 존재할 때만 호출됨
-    List<Boolean> isPredictionCorrect(int homeFormation, int awayFormation, LineupPredictionDto.ResponseLineup homeLineup, LineupPredictionDto.ResponseLineup awayLineup, MatchLineupDto.MatchLineupResponse matchLineup){
+    public List<Boolean> isPredictionCorrect(int homeFormation, int awayFormation, LineupPredictionDto.ResponseLineup homeLineup, LineupPredictionDto.ResponseLineup awayLineup, MatchLineupDto.MatchLineupResponse matchLineup){
         List<Boolean> response = new ArrayList<>();
 
         // 홈팀과 원정팀의 첫 줄 미드 필더와 두 번째 줄 미드필더 미리 합쳐 줌
@@ -306,7 +306,7 @@ public class LineupPredictionService {
     }
 
     // 사용자  or 평균 예측 선발라인업이 정확한지 실제 선발 라인업과 비교해 결과 반환하는 함수
-    private List<ResponsePlayerInfo> convertToPlayerInfo(List<PredictionPlayer> players){
+    public List<ResponsePlayerInfo> convertToPlayerInfo(List<PredictionPlayer> players){
         List<ResponsePlayerInfo> convertedPlayers = new ArrayList<>();
         for (PredictionPlayer player : players){
             convertedPlayers.add(new ResponsePlayerInfo(player.getPlayer()));

--- a/src/main/java/KickIt/server/domain/matchPrediction/controller/MatchPredictionController.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/controller/MatchPredictionController.java
@@ -1,0 +1,72 @@
+package KickIt.server.domain.matchPrediction.controller;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.fixture.entity.FixtureRepository;
+import KickIt.server.domain.matchPrediction.service.MatchPredictionService;
+import KickIt.server.domain.member.entity.Member;
+import KickIt.server.domain.member.entity.MemberRepository;
+import KickIt.server.domain.member.service.MemberService;
+import KickIt.server.jwt.JwtTokenUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/match-predict")
+public class MatchPredictionController {
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    FixtureRepository fixtureRepository;
+    @Autowired
+    MatchPredictionService matchPredictionService;
+
+    @GetMapping()
+    public ResponseEntity<Map<String, Object>> inquireMatchPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+        // 반환할 responseBody
+        Map<String, Object> responseBody = new HashMap<>();
+        // member를 찾기 위해 token으로 email 조회
+        String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
+        // 찾은 email로 member 조회
+        Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
+
+        // 입력된 token의 email로 찾은 member가 존재하는 경우
+        if(foundMember != null){
+            // 경기 id로 경기 조회
+            Fixture foundFixture = fixtureRepository.findById(matchId).orElse(null);
+            // 경기 id로 조회한 경기가 존재하는 경우
+            if(foundFixture != null){
+                responseBody.put("status", HttpStatus.OK.value());
+                responseBody.put("message", "success");
+                responseBody.put("data", matchPredictionService.inquireMatchPrediction(foundFixture, foundMember));
+                responseBody.put("isSuccess", true);
+                return new ResponseEntity<>(responseBody, HttpStatus.OK);
+            }
+            // 경기 id로 조회한 경기가 존재하지 않는 경우
+            else{
+                responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                responseBody.put("message", "해당 경기 없음");
+                responseBody.put("isSuccess", false);
+                return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            }
+        }
+        // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "해당 사용자 없음");
+            responseBody.put("isSuccess", false);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/matchPrediction/dto/MatchPredictionDto.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/dto/MatchPredictionDto.java
@@ -1,0 +1,45 @@
+package KickIt.server.domain.matchPrediction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MatchPredictionDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 경기 예측 조회 Response
+    public static class MatchPredictionInquireResponse{
+        InquiredScorePrediction scorePredictions; // 우승팀 예측 데이터
+        InquiredLineupPrediction lineupPredictions; // 선발라인업 예측 데이터
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 경기 예측 조회 Response 구성 요소 - 선발라인업 예측
+    public static class InquiredLineupPrediction{
+        int homePercentage; // 홈팀의 1순위 포메이션 예측 비율(백분율)
+        int awayPercentage; // 원정팀의 1순위 포메이션 예측 비율(백분율)
+        int homeFormation; // 홈팀의 1순위 예상 포메이션
+        int awayFormation; // 원정팀의 1순위 예상 포메이션
+        Boolean isParticipated; // 사용자가 우승팀 예측을 했는지 여부
+        int participant; // 예측에 참여한 사람의 수 -> 예측 종료 시에만 전송 -> 예측 종료 시에만 전송
+        Boolean isPredictionSuccessful; // 사용자가 예측을 성공했는지 여부 -> 예측 종료 시에만 전송
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    // 경기 예측 조회 Response 구성 요소 - 우승팀 예측
+    public static class InquiredScorePrediction{
+        int homePercentage; // 홈팀의 예측 우승 확률(백분율)
+        Boolean isParticipated; // 사용자가 우승팀 예측을 했는지 여부
+        int participant; // 예측에 참여한 사람의 수 -> 예측 종료 시에만 전송
+        Boolean isPredictionSuccessful; // 사용자가 예측 성공했는지 여부
+    }
+}

--- a/src/main/java/KickIt/server/domain/matchPrediction/service/MatchPredictionService.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/service/MatchPredictionService.java
@@ -1,0 +1,243 @@
+package KickIt.server.domain.matchPrediction.service;
+
+import KickIt.server.domain.fixture.entity.Fixture;
+import KickIt.server.domain.lineup.dto.MatchLineupDto;
+import KickIt.server.domain.lineup.service.MatchLineupService;
+import KickIt.server.domain.lineupPrediction.dto.LineupPredictionDto;
+import KickIt.server.domain.lineupPrediction.entity.LineupPrediction;
+import KickIt.server.domain.lineupPrediction.entity.LineupPredictionRepository;
+import KickIt.server.domain.lineupPrediction.service.LineupPredictionService;
+import KickIt.server.domain.matchPrediction.dto.MatchPredictionDto;
+import KickIt.server.domain.member.entity.Member;
+import KickIt.server.domain.scorePrediction.entity.ScorePrediction;
+import KickIt.server.domain.scorePrediction.entity.ScorePredictionRepository;
+import KickIt.server.domain.scorePrediction.service.ScorePredictionService;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Service
+public class MatchPredictionService {
+    @Autowired
+    ScorePredictionRepository scorePredictionRepository;
+    @Autowired
+    ScorePredictionService scorePredictionService;
+    @Autowired
+    LineupPredictionRepository lineupPredictionRepository;
+    @Autowired
+    LineupPredictionService lineupPredictionService;
+    @Autowired
+    MatchLineupService matchLineupService;
+
+    @Transactional
+    // 경기 예측 데이터 조회
+    public MatchPredictionDto.MatchPredictionInquireResponse inquireMatchPrediction(Fixture fixture, Member member){
+        /* 우승팀 예측 관련 데이터 조회 */
+        // response에 들어갈 우승팀 예측 데이터
+        MatchPredictionDto.InquiredScorePrediction scorePrediction;
+        // 기존에 사용자가 진행한 우승팀 예측 데이터 (없는 경우 null)
+        ScorePrediction userScorePrediction = scorePredictionRepository.findByFixtureAndMember(fixture.getId(), member.getId()).orElse(null);
+        // 우승팀 예측 참여 사용자
+        int scoreParticipant = scorePredictionRepository.findByFixture(fixture.getId()).size();
+
+        // 우승팀 예측 종료 전인 경우 (경기 시작 전) -> participant, isPredictionSuccessful 전송 X
+        if(ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")).isBefore(ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul")))){
+            // 테스트 코드
+            Logger.getGlobal().log(Level.INFO, String.format("우승팀 예측 종료 전: 현재 시간: %s, 경기 시간: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul"))));
+            // 사용자가 기존에 우승팀 예측 진행하지 않은 경우
+            if(userScorePrediction == null){
+                scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
+                        .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
+                        .isParticipated(false)
+                        .build();
+            }
+            // 사용자가 기존에 우승팀 예측 진행한 경우
+            else{
+                scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
+                        .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
+                        .isParticipated(true)
+                        .build();
+            }
+        }
+        // 우승팀 예측 종료된 경우 (경기 시작 후) -> participant, isPredictionSuccessful 포함
+        else{
+            // 테스트 코드
+            Logger.getGlobal().log(Level.INFO, String.format("우승팀 예측 종료 후: 현재 시간: %s, 경기 시간: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul"))));
+            // 사용자가 기존에 우승팀 예측 진행하지 않은 경우
+            if(userScorePrediction == null){
+                scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
+                        .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
+                        .isParticipated(false)
+                        .participant(scoreParticipant)
+                        .build();
+            }
+            // 사용자가 기존에 우승팀 예측 진행한 경우
+            else{
+                // 아직 경기 결과 없는 경우 -> isPredictionSuccessful 제외
+                if(fixture.getHomeTeamScore() == null ){
+                    scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
+                            .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
+                            .isParticipated(true)
+                            .participant(scoreParticipant)
+                            .build();
+                }
+                // 경기 결과 있는 경우
+                else{
+                    scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
+                            .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
+                            .isParticipated(true)
+                            .participant(scoreParticipant)
+                            .isPredictionSuccessful((scorePredictionService.isScoreCorrect(userScorePrediction.getHomeTeamScore(), userScorePrediction.getAwayTeamScore(), fixture) == List.of(true, true) ? true : false))
+                            .build();
+                }
+            }
+        }
+
+        /* 선발라인업 예측 관련 데이터 조회 */
+        // response에 들어갈 선발 라인업 예측 데이터
+        MatchPredictionDto.InquiredLineupPrediction lineupPrediction;
+        // 기존에 사용자가 진행한 우승팀 예측 데이터 (없는 경우 null)
+        LineupPrediction userLineupPrediction = lineupPredictionRepository.findByMemberAndFixture(member.getId(), fixture.getId()).orElse(null);
+        // 선발라인업 예측 참여자 수
+        int lineupParticipant = lineupPredictionRepository.findByFixture(fixture.getId()).size();
+        // 홈팀, 원정팀 예측 1 순위 포메이션 (예측 참가자 0이라 없는 경우 null)
+        Integer homeFormation = lineupPredictionRepository.findAvgHomeTeamForm(fixture.getId());
+        Integer awayFormation = lineupPredictionRepository.findAvgAwayTeamForm(fixture.getId());
+
+        // 선발라인업 예측 종료 전인 경우 (경기 시작 1시간 30분 전) -> participant, isPredictionSuccessful 전송 X
+        if(ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")).isBefore(ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul")))){
+            // 테스트 코드
+            Logger.getGlobal().log(Level.INFO, String.format("선발라인업 예측 종료 전: 현재 시간: %s, 경기 시간 90분 전: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul"))));
+            // 아직 예측 참가자 0인 경우
+            if(lineupParticipant == 0){
+                lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                        .isParticipated(false)
+                        .build();
+            }
+            // 사용자가 기존에 선발라인업 예측 진행하지 않은 경우
+            else if(userLineupPrediction == null){
+                lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                        .homePercentage(figureFormationPercent(fixture.getId(), lineupParticipant, homeFormation, true))
+                        .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
+                        .homeFormation(homeFormation)
+                        .awayFormation(awayFormation)
+                        .isParticipated(false)
+                        .build();
+            }
+            // 사용자가 기존에 선발라인업 예측 진행한 경우
+            else{
+                lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                        .homePercentage(figureFormationPercent(fixture.getId(), lineupParticipant, homeFormation, true))
+                        .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
+                        .homeFormation(homeFormation)
+                        .awayFormation(awayFormation)
+                        .isParticipated(true)
+                        .build();
+            }
+        }
+        // 선발라인업 예측 종료 후인 경우 (경기 시작 1시간 30분 전 후) -> participant, isPredictionSuccessful 전송
+        else{
+            // 테스트 코드
+            Logger.getGlobal().log(Level.INFO, String.format("선발라인업 예측 종료 후: 현재 시간: %s, 경기 시간 90분 전: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul"))));
+            // 아직 예측 참가자 0인 경우
+            if(lineupParticipant == 0){
+                lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                        .isParticipated(false)
+                        .participant(lineupParticipant)
+                        .build();
+            }
+            // 사용자가 기존에 선발라인업 예측 진행하지 않은 경우
+            else if(userLineupPrediction == null){
+                lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                        .homePercentage(figureFormationPercent(fixture.getId(), lineupParticipant, homeFormation, true))
+                        .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
+                        .homeFormation(homeFormation)
+                        .awayFormation(awayFormation)
+                        .isParticipated(false)
+                        .participant(lineupParticipant)
+                        .build();
+            }
+            // 사용자가 기존에 선발라인업 예측 진행한 경우
+            else{
+                // 실제 선발라인업 정보 (크롤링 시도 후 아직 선발라인업 정보 없어 timeout 시 null)
+                MatchLineupDto.MatchLineupResponse matchLineup = matchLineupService.findMatchLineupByFixture(fixture.getId());
+                // 실제 선발 라인업 정보 없는 경우
+                if(matchLineup == null){
+                    lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                            .homePercentage(figureFormationPercent(fixture.getId(), lineupParticipant, homeFormation, true))
+                            .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
+                            .homeFormation(homeFormation)
+                            .awayFormation(awayFormation)
+                            .isParticipated(true)
+                            .participant(lineupParticipant)
+                            .build();
+                }
+                // 실제 선발 라인업 정보 조회되는 경우
+                else{
+                    // 사용자가 예측한 홈팀 라인업 정보 실제와 일치하는지 체크할 수 있는 형태 객체로 생성
+                    LineupPredictionDto.ResponseLineup homeLineup = LineupPredictionDto.ResponseLineup.builder()
+                            .goalkeeper(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 0, 0)).get(0))
+                            .defenders(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 1, 0)))
+                            .midfielders(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 2, 0)))
+                            .strikers(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 3, 0)))
+                            .build();
+                    // 사용자가 예측한 원정팀 라인업 정보 실제와 일치하는지 체크할 수 있는 형태 객체로 생성
+                    LineupPredictionDto.ResponseLineup awayLineup = LineupPredictionDto.ResponseLineup.builder()
+                            .goalkeeper(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 0, 1)).get(0))
+                            .defenders(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 1, 1)))
+                            .midfielders(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 2, 1)))
+                            .strikers(lineupPredictionService.convertToPlayerInfo(lineupPredictionRepository.findFilteredPlayersByMemberAndFixture(member.getId(), fixture.getId(), 3, 1)))
+                            .build();
+
+                    lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
+                            .homePercentage(figureFormationPercent(fixture.getId(), lineupParticipant, homeFormation, true))
+                            .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
+                            .homeFormation(homeFormation)
+                            .awayFormation(awayFormation)
+                            .isParticipated(true)
+                            .participant(lineupParticipant)
+                            .isPredictionSuccessful(lineupPredictionService.isPredictionCorrect(homeFormation, awayFormation, homeLineup, awayLineup, matchLineup) == List.of(true, true)? true : false)
+                            .build();
+                }
+            }
+        }
+        return MatchPredictionDto.MatchPredictionInquireResponse.builder()
+                .lineupPredictions(lineupPrediction)
+                .scorePredictions(scorePrediction)
+                .build();
+    }
+
+    // 홈팀과 원정팀 예상 점수로 홈팀 우승 예측 백분율 구하는 method
+    int figureHomeWinningPercent(Long fixtureId, Integer participant){
+        // 만약 예측 진행한 사람이 0 인 경우 0 반환
+        if(participant == 0) {return 0;}
+
+        int homeWinningParticipants = scorePredictionRepository.findHomeWinningParticipants(fixtureId);
+        int percent = homeWinningParticipants / participant * 100;
+        return percent;
+    }
+
+    // 홈팀과 원정팀 예측 1순위 포메이션의 참여자 예측 백분율 구하는 method
+    int figureFormationPercent(Long fixtureId, Integer participant, Integer formation, Boolean isHomeTeam){
+        // 만약 예측 진행한 사람이 0 인 경우 0 반환
+        if(participant == 0) { return 0;}
+
+        int percent;
+        if(isHomeTeam){
+            percent = lineupPredictionRepository.findAvgHomeTeamFormParticipant(fixtureId, formation) / participant * 100;
+        }
+        else{
+            percent = lineupPredictionRepository.findAvgAwayTeamFormParticipant(fixtureId, formation) / participant * 100;
+        }
+        return percent;
+    }
+}

--- a/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePredictionRepository.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/entity/ScorePredictionRepository.java
@@ -19,4 +19,7 @@ public interface ScorePredictionRepository extends JpaRepository<ScorePrediction
 
     @Query("SELECT s.awayTeamScore, COUNT(s.awayTeamScore) AS count FROM ScorePrediction s WHERE s.fixture.id = :fixtureId GROUP BY s.awayTeamScore ORDER BY count DESC, MAX(s.lastUpdated) DESC LIMIT 1")
     Integer findAvgAwayTeamScore(@Param("fixtureId") Long fixtureId);
+
+    @Query("SELECT COUNT(s) FROM ScorePrediction s WHERE s.fixture.id = :fixtureId AND s.homeTeamScore >= s.awayTeamScore")
+    Integer findHomeWinningParticipants(@Param("fixtureId") Long fixtureId);
 }

--- a/src/main/java/KickIt/server/domain/scorePrediction/service/ScorePredictionService.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/service/ScorePredictionService.java
@@ -78,7 +78,7 @@ public class ScorePredictionService {
                     .avgAwayTeamScore(scorePredictionRepository.findAvgAwayTeamScore(fixtureId))
                     .build();
         }
-        // 경기 결과가 아직 나오지 않은 경우
+        // 경기 결과가 나온 경우
         else{
             int avgHomeTeamScore = scorePredictionRepository.findAvgHomeTeamScore(fixtureId);
             int avgAwayTeamScore = scorePredictionRepository.findAvgAwayTeamScore(fixtureId);
@@ -95,7 +95,7 @@ public class ScorePredictionService {
         return response;
     }
 
-    List<Boolean> isScoreCorrect(int homeTeamScore, int awayTeamScore, Fixture fixture){
+    public List<Boolean> isScoreCorrect(int homeTeamScore, int awayTeamScore, Fixture fixture){
         List<Boolean> response = new ArrayList<>();
 
         // 실제 점수와 예측 점수 비교


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #83 
<br>
closed jira #125

## ✨ 변경 사항 및 이유
- 경기 정보 화면에서 경기 예측 버튼을 클릭하면 호출되는 경기 예측 조회 GET API 개발
- 우승팀 예측 정보 + 선발라인업 예측 정보의 형태
- 사용자들의 홈팀 승리 예측, 1순위 예측 선발라인업 백분율 계산 기능 필요
- 우승팀 예측 종료 시점, 선발라인업 예측 종료 시점 이전인지 이후인지 파악하는 기능 필요
