### PR TITLE
현재 시즌 랭킹 조회 API 개발 / 기존 API JWT Token beraer로 변경

### DIFF
--- a/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
@@ -39,7 +39,7 @@ public class LineupPredictionController {
     // 입력 받은 정보 바탕으로 사용자의 경기 선발 라인업 예측을 DB에 POST
     // JWT 될 때까지 일단 member id로 처리 -> 차후 변경 예정
     @PostMapping("/save")
-    public ResponseEntity<Map<String, Object>> saveLineupPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") long matchId, @RequestBody LineupPredictionDto.LineUpPredictionRequest lineUpPredictionRequest){
+    public ResponseEntity<Map<String, Object>> saveLineupPrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") long matchId, @RequestBody LineupPredictionDto.LineUpPredictionRequest lineUpPredictionRequest){
         String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
         Member member = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
         Map<String, Object> responseBody = new HashMap<>();
@@ -167,7 +167,7 @@ public class LineupPredictionController {
     // 입력 받은 정보 바탕으로 사용자의 기존 경기 선발 라인업 예측을 수정
     // JWT 될 때까지 일단 member id로 처리 -> 차후 변경 예정
     @PatchMapping("/edit")
-    public ResponseEntity<Map<String, Object>> editLineupPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") long matchId, @RequestBody LineupPredictionDto.LineUpPredictionRequest lineUpPredictionRequest){
+    public ResponseEntity<Map<String, Object>> editLineupPrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") long matchId, @RequestBody LineupPredictionDto.LineUpPredictionRequest lineUpPredictionRequest){
         String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
         Member member = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
         Map<String, Object> responseBody = new HashMap<>();
@@ -281,7 +281,7 @@ public class LineupPredictionController {
     // 사용자의 선발 라인업 예측 정보 조회
     // JWT 될 때까지 일단 member id로 처리 -> 차후 변경 예정
     @GetMapping()
-    public ResponseEntity<Map<String, Object>> getUserLineupPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> getUserLineupPrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
         Member member = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
         Map<String, Object> responseBody = new HashMap<>();
@@ -330,7 +330,7 @@ public class LineupPredictionController {
     // 선발 라인업 예측 결과 정보 조회 (전체)
     // JWT 될 때까지 일단 member id로 처리 -> 차후 변경 예정
     @GetMapping("/result")
-    public ResponseEntity<Map<String, Object>> getLineupPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId) {
+    public ResponseEntity<Map<String, Object>> getLineupPrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId) {
         String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
         Member member = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
         Map<String, Object> responseBody = new HashMap<>();

--- a/src/main/java/KickIt/server/domain/matchPrediction/controller/MatchPredictionController.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/controller/MatchPredictionController.java
@@ -10,10 +10,7 @@ import KickIt.server.jwt.JwtTokenUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +30,7 @@ public class MatchPredictionController {
     MatchPredictionService matchPredictionService;
 
     @GetMapping()
-    public ResponseEntity<Map<String, Object>> inquireMatchPrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> inquireMatchPrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회

--- a/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
@@ -32,7 +32,7 @@ public class ScorePredictionController {
     ScorePredictionService scorePredictionService;
 
     @PostMapping("/save")
-    public ResponseEntity<Map<String, Object>> saveScorePrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
+    public ResponseEntity<Map<String, Object>> saveScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -92,7 +92,7 @@ public class ScorePredictionController {
     }
 
     @PatchMapping("/edit")
-    public ResponseEntity<Map<String, Object>> editScorePrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
+    public ResponseEntity<Map<String, Object>> editScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -137,7 +137,7 @@ public class ScorePredictionController {
     }
 
     @GetMapping()
-    public ResponseEntity<Map<String, Object>> inquireScorePrediction(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> inquireScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -187,7 +187,7 @@ public class ScorePredictionController {
     }
 
     @GetMapping("/result")
-    public ResponseEntity<Map<String, Object>> inquireScorePredictionResult(@RequestParam("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> inquireScorePredictionResult(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회

--- a/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
+++ b/src/main/java/KickIt/server/domain/scorePrediction/controller/ScorePredictionController.java
@@ -32,7 +32,7 @@ public class ScorePredictionController {
     ScorePredictionService scorePredictionService;
 
     @PostMapping("/save")
-    public ResponseEntity<Map<String, Object>> saveScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
+    public ResponseEntity<Map<String, Object>> saveScorePrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -92,7 +92,7 @@ public class ScorePredictionController {
     }
 
     @PatchMapping("/edit")
-    public ResponseEntity<Map<String, Object>> editScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
+    public ResponseEntity<Map<String, Object>> editScorePrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId, @RequestBody ScorePredictionDto.ScorePredictionSaveRequest scorePredictionSaveRequest){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -137,7 +137,7 @@ public class ScorePredictionController {
     }
 
     @GetMapping()
-    public ResponseEntity<Map<String, Object>> inquireScorePrediction(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> inquireScorePrediction(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회
@@ -187,7 +187,7 @@ public class ScorePredictionController {
     }
 
     @GetMapping("/result")
-    public ResponseEntity<Map<String, Object>> inquireScorePredictionResult(@RequestHeader("xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
+    public ResponseEntity<Map<String, Object>> inquireScorePredictionResult(@RequestHeader(value = "xAuthToken") String xAuthToken, @RequestParam("matchId") Long matchId){
         // 반환할 responseBody
         Map<String, Object> responseBody = new HashMap<>();
         // member를 찾기 위해 token으로 email 조회

--- a/src/main/java/KickIt/server/domain/teams/controller/RankingController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/RankingController.java
@@ -1,0 +1,66 @@
+package KickIt.server.domain.teams.controller;
+
+import KickIt.server.domain.member.entity.Member;
+import KickIt.server.domain.member.entity.MemberRepository;
+import KickIt.server.domain.member.service.MemberService;
+import KickIt.server.domain.teams.dto.RankingDto;
+import KickIt.server.domain.teams.entity.Ranking;
+import KickIt.server.domain.teams.service.RankingService;
+import KickIt.server.jwt.JwtTokenUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/ranking")
+public class RankingController {
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    RankingService rankingService;
+
+    @GetMapping("")
+    public ResponseEntity<Map<String, Object>> inquireRanking(@RequestHeader(value = "xAuthToken") String xAuthToken){
+        // 반환할 responseBody
+        Map<String, Object> responseBody = new HashMap<>();
+        // member를 찾기 위해 token으로 email 조회
+        String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
+        // 찾은 email로 member 조회
+        Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
+
+        // 입력된 token의 email로 찾은 member가 존재하는 경우
+        if(foundMember != null){
+            RankingDto.RankingResponse response = rankingService.inquireRanking();
+            if(response != null){
+                responseBody.put("status", HttpStatus.OK.value());
+                responseBody.put("message", "success");
+                responseBody.put("data", response);
+                responseBody.put("isSuccess", true);
+                return new ResponseEntity<>(responseBody, HttpStatus.OK);
+            }
+            else{
+                responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                responseBody.put("message", "랭킹 데이터 블러오지 못 함");
+                responseBody.put("data", response);
+                responseBody.put("isSuccess", false);
+                return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            }
+        }
+        // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "해당 사용자 없음");
+            responseBody.put("isSuccess", false);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/dto/RankingDto.java
+++ b/src/main/java/KickIt/server/domain/teams/dto/RankingDto.java
@@ -1,0 +1,38 @@
+package KickIt.server.domain.teams.dto;
+
+import KickIt.server.domain.teams.entity.Ranking;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankingDto {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RankingResponse{
+        List<RankInfo> rankings;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RankInfo{
+        int ranking; // 순위
+        String teamUrl; // 팀 엠블럼 주소
+        String teamName; // 팀 명칭
+        int totalMatches; // 각 팀이 치른 경기 횟수
+        int wins; // 각 팀의 승리 횟수
+        int draws; // 각 팀의 무승부 횟수
+        int losses; // 각 팀의 패배 횟수
+        int points; // 각 팀이 획득한 승점;
+        // 리그 카테고리
+        // 0: 디폴트
+        // 1: 챔피언스리그 O
+        // 2: 유로파리그 O
+        // 3: 강등권 O
+        int leagueCategory;
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/Ranking.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/Ranking.java
@@ -1,0 +1,48 @@
+package KickIt.server.domain.teams.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ranking")
+// 시즌 별 프리미어리그 팀 순위 정보
+public class Ranking {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // id(자동 생성)
+    private long id;
+    // 팀 정보(내부에 시즌 정보 포함)
+    @OneToOne
+    Squad squad;
+    // 순위 정보
+    int teamRank;
+    // 팀 경기 횟수
+    int matchCount;
+    // 승리 횟수
+    int winCount;
+    // 무승부 횟수
+    int drawCount;
+    // 패배 횟수
+    int loseCount;
+    // 승점
+    int points;
+
+    // 수정 시각을 저장하는 필드
+    @Column(name = "last_updated", nullable = false)
+    private LocalDateTime lastUpdated;
+
+    @PrePersist
+    @PreUpdate
+    public void setLastUpdated() {
+        this.lastUpdated = LocalDateTime.now();
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/entity/RankingRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/RankingRepository.java
@@ -13,6 +13,6 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
     @Query(value = "SELECT r FROM Ranking r ORDER BY r.lastUpdated LIMIT 1")
     Optional<Ranking> findNewestRank();
 
-    @Query(value = "SELECT r FROM Ranking r WHERE r.squad.season = :season")
+    @Query(value = "SELECT r FROM Ranking r WHERE r.squad.season = :season ORDER BY r.teamRank ASC")
     List<Ranking> findBySeason(@Param("season") String season);
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/RankingRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/RankingRepository.java
@@ -1,0 +1,18 @@
+package KickIt.server.domain.teams.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RankingRepository extends JpaRepository<Ranking, Long> {
+    @Query(value = "SELECT r FROM Ranking r ORDER BY r.lastUpdated LIMIT 1")
+    Optional<Ranking> findNewestRank();
+
+    @Query(value = "SELECT r FROM Ranking r WHERE r.squad.season = :season")
+    List<Ranking> findBySeason(@Param("season") String season);
+}

--- a/src/main/java/KickIt/server/domain/teams/service/RankingService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/RankingService.java
@@ -1,0 +1,129 @@
+package KickIt.server.domain.teams.service;
+
+import KickIt.server.domain.teams.dto.RankingDto;
+import KickIt.server.domain.teams.entity.Ranking;
+import KickIt.server.domain.teams.entity.RankingRepository;
+import KickIt.server.global.common.crawler.RankingCrawler;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class RankingService {
+    @Autowired
+    RankingRepository rankingRepository;
+    @Autowired
+    RankingCrawler rankingCrawler;
+    @Autowired
+    TeamNameConvertService teamNameConvertService;
+
+    @Transactional
+    // 현재 시즌 랭킹 조회
+    public RankingDto.RankingResponse inquireRanking(){
+        Ranking newestRank = rankingRepository.findNewestRank().orElse(null);
+        // 아직 랭킹 데이터 없음 => 크롤링
+        if(newestRank == null){
+            // 크롤링해 온 랭킹 정보
+            List<Ranking> rankingList = saveRankingCrawl();
+            if(rankingList == null){ return null; } // null인 경우 변환 절차 없이 반환
+
+            // 가져온 랭킹 정보 dto class로 변환해 반환
+            List<RankingDto.RankInfo> rankings = new ArrayList<>();
+            for(Ranking ranking : rankingList){
+                rankings.add(RankingDto.RankInfo.builder()
+                        .ranking(ranking.getTeamRank())
+                        .teamUrl(ranking.getSquad().getLogoImg())
+                        .teamName(teamNameConvertService.convertToKrName(ranking.getSquad().getTeam()))
+                        .totalMatches(ranking.getMatchCount())
+                        .wins(ranking.getWinCount())
+                        .draws(ranking.getDrawCount())
+                        .losses(ranking.getLoseCount())
+                        .points(ranking.getPoints())
+                        .leagueCategory(findLeagueCategory(ranking.getTeamRank()))
+                        .build());
+            }
+            RankingDto.RankingResponse response = RankingDto.RankingResponse.builder()
+                    .rankings(rankings).build();
+            return response;
+        }
+        // 가장 최근 데이터 1 개와 현재 시간 비교
+        long duration = Duration.between(ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(rankingRepository.findNewestRank().get().getLastUpdated().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul"))).toMinutes();
+        // 가장 최근에 저장된 데이터가 1분 이상 차이 나지 않으면 DB에 있는 값 그대로 반환
+        if (duration <= 1){
+            // 가장 최근 시즌 정보
+            String season = newestRank.getSquad().getSeason();
+            // 해당 시즌 정보 가져옴
+            List<Ranking> rankingList = rankingRepository.findBySeason(season);
+            // dto class 대로 변환해 반환
+            List<RankingDto.RankInfo> rankings = new ArrayList<>();
+            for(Ranking ranking : rankingList){
+                rankings.add(RankingDto.RankInfo.builder()
+                        .ranking(ranking.getTeamRank())
+                        .teamUrl(ranking.getSquad().getLogoImg())
+                        .teamName(teamNameConvertService.convertToKrName(ranking.getSquad().getTeam()))
+                        .totalMatches(ranking.getMatchCount())
+                        .wins(ranking.getWinCount())
+                        .draws(ranking.getDrawCount())
+                        .losses(ranking.getLoseCount())
+                        .points(ranking.getPoints())
+                        .leagueCategory(findLeagueCategory(ranking.getTeamRank()))
+                        .build());
+            }
+            RankingDto.RankingResponse response = RankingDto.RankingResponse.builder()
+                    .rankings(rankings).build();
+            return response;
+        }
+        // 가자 최근에 저장된 데이터가 1분 이상 차이 나면 크롤링해 DB에 업데이트 후 반환
+        else{
+            // 크롤링해 온 랭킹 정보
+            List<Ranking> rankingList = saveRankingCrawl();
+            if(rankingList == null){ return null; } // null인 경우 변환 절차 없이 반환
+
+            // 가져온 랭킹 정보 dto class로 변환해 반환
+            List<RankingDto.RankInfo> rankings = new ArrayList<>();
+            for(Ranking ranking : rankingList){
+                rankings.add(RankingDto.RankInfo.builder()
+                        .ranking(ranking.getTeamRank())
+                        .teamUrl(ranking.getSquad().getLogoImg())
+                        .teamName(teamNameConvertService.convertToKrName(ranking.getSquad().getTeam()))
+                        .totalMatches(ranking.getMatchCount())
+                        .wins(ranking.getWinCount())
+                        .draws(ranking.getDrawCount())
+                        .losses(ranking.getLoseCount())
+                        .points(ranking.getPoints())
+                        .leagueCategory(findLeagueCategory(ranking.getTeamRank()))
+                        .build());
+            }
+            RankingDto.RankingResponse response = RankingDto.RankingResponse.builder()
+                    .rankings(rankings).build();
+            return response;
+        }
+    }
+
+    // 현재 랭킹 데이터 크롤링해 DB에 저장
+    @Transactional
+    public List<Ranking> saveRankingCrawl(){
+        List<Ranking> rankingList = rankingCrawler.getRanking();
+        if(rankingList == null){
+            return null;
+        }
+        for(Ranking ranking : rankingList){ rankingRepository.save(ranking); }
+        return rankingList;
+    }
+
+    public int findLeagueCategory(int rank){
+        return switch (rank){
+            case 1, 2, 3, 4 -> 1;
+            case 5 -> 2;
+            case 18, 19, 20 -> 3;
+            default -> 0;
+        };
+    }
+}

--- a/src/main/java/KickIt/server/domain/teams/service/RankingService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/RankingService.java
@@ -64,6 +64,7 @@ public class RankingService {
             String season = newestRank.getSquad().getSeason();
             // 해당 시즌 정보 가져옴
             List<Ranking> rankingList = rankingRepository.findBySeason(season);
+            Logger.getGlobal().log(Level.INFO, rankingList.size() + "");
             // dto class 대로 변환해 반환
             List<RankingDto.RankInfo> rankings = new ArrayList<>();
             for(Ranking ranking : rankingList){
@@ -117,9 +118,10 @@ public class RankingService {
         if(rankingList == null){
             return null;
         }
+        // 전체 데이터 삭제 후 저장
+        rankingRepository.deleteAll();
+
         for(Ranking ranking : rankingList){
-            // 전체 데이터 삭제 후 저장
-            rankingRepository.deleteAll();
             rankingRepository.save(ranking);
         }
         return rankingList;

--- a/src/main/java/KickIt/server/global/common/crawler/RankingCrawler.java
+++ b/src/main/java/KickIt/server/global/common/crawler/RankingCrawler.java
@@ -1,0 +1,122 @@
+package KickIt.server.global.common.crawler;
+
+import KickIt.server.domain.teams.entity.Ranking;
+import KickIt.server.domain.teams.entity.Squad;
+import KickIt.server.domain.teams.entity.SquadRepository;
+import KickIt.server.domain.teams.service.TeamNameConvertService;
+import KickIt.server.global.util.WebDriverUtil;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.Integer.parseInt;
+
+// 시즌별 랭킹 정보를 가지고 오는 crawler
+// 기존 TeamInfoCrawler에서 Squad Crawler와 겹치는 부분은 제외하고 승-무-패 횟수 크롤링 부분 추가
+// 차후 TeamInfoCrawler는 삭제 예정
+@Component
+public class RankingCrawler {
+    @Autowired
+    TeamNameConvertService teamNameConvertService;
+    @Autowired
+    SquadRepository squadRepository;
+
+    public List<Ranking> getRanking() {
+        WebDriver driver = WebDriverUtil.getChromeDriver();
+
+        // 웹 페이지로 이동
+        String url = "https://sports.daum.net/record/epl/team";
+
+        List<Ranking> rankingList = new ArrayList<>();
+
+        if (!ObjectUtils.isEmpty(driver)) {
+            try {
+                // 페이지 열고 타임 아웃 관련 처리
+                driver.get(url);
+                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(15));
+
+                List<WebElement> teaminfoRows = driver.findElements(By.cssSelector("tbody > tr"));
+                for (WebElement row : teaminfoRows) {
+                    if (teaminfoRows.indexOf(row) >= teaminfoRows.size()) {
+                        Logger.getGlobal().log(Level.WARNING, "인덱스가 리스트 범위를 벗어났습니다: " + teaminfoRows.indexOf(row));
+                        continue; // 혹은 다른 적절한 처리
+                    }
+
+                    String season = driver.findElement(By.className("emph_day")).getText();
+
+                    String teamName = getTeamName(row);
+                    Squad squad = squadRepository.findBySeasonAndTeam(season, teamNameConvertService.convertFromKrName(teamName)).orElse(null);
+                    if(squad == null){ Logger.getGlobal().log(Level.INFO, String.format("squad 찾을 수 없음: season %s, teamname %s", season, teamName));}
+                    else{
+                        Ranking rank = Ranking.builder()
+                                .squad(squad)
+                                .teamRank(getRanking(row))
+                                .matchCount(getMatchCount(row))
+                                .winCount(getWinCount(row))
+                                .drawCount(getDrawCount(row))
+                                .loseCount(getLoseCount(row))
+                                .points(getPoint(row))
+                                .build();
+                        rankingList.add(rank);
+                    }
+                }
+
+            }
+            catch (Exception e) {
+                Logger.getGlobal().log(Level.INFO, "RankingCrawler 오류: " + e);
+                rankingList = null;
+            }
+            finally {
+                WebDriverUtil.quit(driver);
+            }
+        }
+
+        return rankingList;
+
+    }
+
+    int getRanking(WebElement row){
+        String rankingAll = row.findElement(By.className("td_rank")).getText();
+        int rankingInt = parseInt(rankingAll.replaceAll("[^0-9].*",""));
+        return rankingInt;
+    }
+
+    String getTeamName(WebElement row) {
+        String team = row.findElement(By.className("txt_name")).getText();
+        return team;
+    }
+
+    int getMatchCount(WebElement row){
+        int matchCount = parseInt(row.findElements(By.tagName("td")).get(2).getText());
+        return matchCount;
+    }
+
+    int getWinCount(WebElement row){
+        int winCount = parseInt(row.findElements(By.tagName("td")).get(3).getText());
+        return winCount;
+    }
+
+    int getDrawCount(WebElement row){
+        int drawCount = parseInt(row.findElements(By.tagName("td")).get(4).getText());
+        return drawCount;
+    }
+
+    int getLoseCount(WebElement row){
+        int loseCount = parseInt(row.findElements(By.tagName("td")).get(5).getText());
+        return loseCount;
+    }
+
+    int getPoint(WebElement row){
+        int point = parseInt(row.findElements(By.tagName("td")).get(9).getText());
+        return point;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,8 @@ spring.web.resources.add-mappings=false
 # MySQL ??
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/KickItDB?useSSL=false&serverTimezone=Asia/Seoul&sendStringParametersAsUnicode=false
-spring.datasource.username=root
-spring.datasource.password=server
+spring.datasource.username=kickit
+spring.datasource.password=kickit_server
 
 # JPA ??? ??
 spring.jpa.show-sql=true


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #85, #89 
<br>
closed jira #129, #133

## ✨ 변경 사항 및 이유
- 현재 시즌의 랭킹 데이터 조회하는 현재 시즌 랭킹 조회 API 개발
- DB에서 가장 최근에 업데이트 된 시간을 기준으로 1분 이내이면 그냥 반환 / 1분 이상이면 크롤링 해 DB 업데이트 후 반환 
- 지금까지 개발한 API JWT token header에 포함되는 bearer 형식으로 코드 변경