### PR TITLE
🎉 Feat: 최근 시즌 팀 이름, URL 조회 API 개발

### DIFF
--- a/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
@@ -1,10 +1,14 @@
 package KickIt.server.domain.teams.controller;
 
+import KickIt.server.domain.member.entity.Member;
+import KickIt.server.domain.member.entity.MemberRepository;
+import KickIt.server.domain.member.service.MemberService;
 import KickIt.server.domain.teams.dto.SquadDto;
 import KickIt.server.domain.teams.entity.Squad;
 import KickIt.server.domain.teams.service.SquadService;
 import KickIt.server.global.common.crawler.FixtureCrawler;
 import KickIt.server.global.common.crawler.SquadCrawler;
+import KickIt.server.jwt.JwtTokenUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +26,12 @@ public class SquadController {
     SquadService squadService;
     @Autowired
     SquadCrawler squadCrawler;
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MemberService memberService;
 
     @PostMapping("/crawl")
     @ResponseStatus(HttpStatus.CREATED)
@@ -56,6 +66,44 @@ public class SquadController {
         else{
             responseBody.put("status", HttpStatus.NOT_FOUND.value());
             responseBody.put("message", "현재 시즌 팀 데이터 조회 실패");
+            responseBody.put("isSuccess", false);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @GetMapping("name-url/withAuth")
+    // 현재 시즌 프리미어리그 팀 전체의 이름과 로고 이미지 조회 API (xAuthToken 있음)
+    public ResponseEntity<Map<String, Object>> inquireEplTeamNameAndUrl(@RequestHeader(value = "xAuthToken") String xAuthToken){
+        // 반환할 response
+        Map<String, Object> responseBody = new HashMap<>();
+        // member를 찾기 위해 token으로 email 조회
+        String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
+        // 찾은 email로 member 조회
+        Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
+
+        // 입력된 token의 email로 찾은 member가 존재하는 경우
+        if(foundMember != null){
+            List<SquadDto.EplNameUrlResponse> data = squadService.getEplTeamNameAndUrl();
+            // 등록된 것 중 가장 최근 시즌의 Squad 데이터 조회 완료
+            if(data != null){
+                responseBody.put("status", HttpStatus.OK.value());
+                responseBody.put("message", "success");
+                responseBody.put("data", data);
+                responseBody.put("isSuccess", true);
+                return new ResponseEntity<>(responseBody, HttpStatus.OK);
+            }
+            // 조회한 squad 데이터가 없는 경우
+            else{
+                responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                responseBody.put("message", "현재 시즌 팀 데이터 조회 실패");
+                responseBody.put("isSuccess", false);
+                return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            }
+        }
+        // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "해당 사용자 없음");
             responseBody.put("isSuccess", false);
             return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
         }

--- a/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
@@ -1,5 +1,6 @@
 package KickIt.server.domain.teams.controller;
 
+import KickIt.server.domain.teams.dto.SquadDto;
 import KickIt.server.domain.teams.entity.Squad;
 import KickIt.server.domain.teams.service.SquadService;
 import KickIt.server.global.common.crawler.FixtureCrawler;
@@ -33,6 +34,30 @@ public class SquadController {
         responseBody.put("status", HttpStatus.OK.value());
         responseBody.put("message", "success");
         responseBody.put("data", squadList);
+        responseBody.put("isSuccess", true);
         return new ResponseEntity<>(responseBody, HttpStatus.OK);
+    }
+
+    @GetMapping("name-url")
+    // 현재 시즌 프리미어리그 팀 전체의 이름과 로고 이미지 조회 API
+    public ResponseEntity<Map<String, Object>> inquireEplTeamNameAndUrl(){
+        // 반환할 response
+        Map<String, Object> responseBody = new HashMap<>();
+        List<SquadDto.EplNameUrlResponse> data = squadService.getEplTeamNameAndUrl();
+        // 등록된 것 중 가장 최근 시즌의 Squad 데이터 조회 완료
+        if(data != null){
+            responseBody.put("status", HttpStatus.OK.value());
+            responseBody.put("message", "success");
+            responseBody.put("data", data);
+            responseBody.put("isSuccess", true);
+            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        }
+        // 조회한 squad 데이터가 없는 경우
+        else{
+            responseBody.put("status", HttpStatus.NOT_FOUND.value());
+            responseBody.put("message", "현재 시즌 팀 데이터 조회 실패");
+            responseBody.put("isSuccess", false);
+            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/KickIt/server/domain/teams/dto/SquadDto.java
+++ b/src/main/java/KickIt/server/domain/teams/dto/SquadDto.java
@@ -45,4 +45,12 @@ public class SquadDto {
             this.players = squad.getPlayers();
         }
     }
+
+    @Data
+    @Builder
+    // 프리미어리그 팀, Url 조회 API 호출 시 반환할 Response class
+    public static class EplNameUrlResponse{
+        private String teamUrl;
+        private String teamName;
+    }
 }

--- a/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
+++ b/src/main/java/KickIt/server/domain/teams/entity/SquadRepository.java
@@ -21,4 +21,7 @@ public interface SquadRepository extends JpaRepository<Squad, Long>{
 
     @Query("SELECT logoImg FROM Squad WHERE team = :team")
     String getUrl(@Param("team") String team);
+
+    @Query(value = "SELECT s.season FROM Squad s ORDER BY s.season DESC LIMIT 1")
+    Optional<String> getNewestSeason();
 }

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -95,4 +95,22 @@ public class SquadService {
         }
         return null;
     }
+
+    // 현재(최근) 시즌 팀 이름과 Url 반환
+    @Transactional
+    public List<SquadDto.EplNameUrlResponse> getEplTeamNameAndUrl(){
+        String presentSeason = squadRepository.getNewestSeason().orElse(null);
+        if(presentSeason == null){
+            return null;
+        }
+        List<SquadDto.EplNameUrlResponse> response = new ArrayList<>();
+        List<Squad> squadList = squadRepository.findBySeason(presentSeason);
+        for(Squad squad : squadList){
+            response.add(SquadDto.EplNameUrlResponse.builder()
+                    .teamName(teamNameConvertService.convertToKrName(squad.getTeam()))
+                    .teamUrl(squad.getLogoImg())
+                    .build());
+        }
+        return response;
+    }
 }


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #86 
<br>
closed jira #130

## ✨ 변경 사항 및 이유
- 프리미어리그의 모든 팀 정보를 조회하는 GET API 개발
- 반환 값에는 각 팀의 엠블럼 URL과 팀 이름을 포함
- 기존에 시즌 팀 / 선수 정보 크롤링 API가 POST 했던 DB 데이터 반환
