### PR TITLE
기록하고 싶은 경기 선택을 위한 경기 일정 조회 GET API 개발 완료

### DIFF
--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -119,4 +119,26 @@ public class FixtureDto {
         }
     }
 
+    @Data
+    @Builder
+    public static class DiaryFixtureResponse{
+        private List<String> soccerTeamNames; // 해당 년도/월에 따른 프리미어리그 내의 전체 팀 이름 리스트
+        private List<DiaryFixture> matches; // 경기 리스트
+        private Boolean isLeftExist; // 왼쪽 달 경기 조회 가능 여부 (이전 달에 경기 있는지 체크)
+        private Boolean isRightExist; // 오른쪽 달 경기 조회 가능 여부 (다음 달에 경기 있는지 체크)
+    }
+
+    @Data
+    @Builder
+    public static class DiaryFixture{
+        private Long matchId; // 축구 경기 고유 ID
+        private String matchDate; // 축구 경기 날짜
+        private String matchTime; // 축구 경기 시간
+        private String homeTeamEmblemURL; // 홈팀 로고 이미지 URL
+        private String awayTeamEmblemUrl; // 원정팀 로고 이미지 URL
+        private String homeTeamName; // 홈팀 이름
+        private String awayTeamName; // 원정팀 이름
+        private Integer homeTeamScore; // 홈팀 스코어
+        private Integer awayTeamScore; // 원정팀 스코어
+    }
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -128,14 +128,18 @@ public class FixtureService {
     @Transactional
     public FixtureDto.DiaryFixtureResponse findDiaryFixturesByMonth(int year, int month){
         List<FixtureDto.DiaryFixture> diaryFixtures = new ArrayList<>();
+        // 가져온 경기 리스트
         List<Fixture> fixtureList = fixtureRepository.findByMonth(year, month);
 
-        Boolean isLeftExist;
-        Boolean isRightExist;
+        Boolean isLeftExist; // 이전 달에 경기 존재하는지 여부
+        Boolean isRightExist; // 다음 달에 경기 존재하는지 여부
+
+        // 1월인 경우 이전 달 작년 12월로 변경해 조회
         if(month == 1){
             isLeftExist = !fixtureRepository.findByMonth(year-1, 12).isEmpty();
             isRightExist = !fixtureRepository.findByMonth(year, month+1).isEmpty();
         }
+        // 12월인 경우 다음 달 내년 1월로 변경해 조회
         else if(month == 12){
             isLeftExist = !fixtureRepository.findByMonth(year, month-1).isEmpty();
             isRightExist = !fixtureRepository.findByMonth(year+1, 1).isEmpty();
@@ -144,7 +148,7 @@ public class FixtureService {
             isLeftExist = !fixtureRepository.findByMonth(year, month-1).isEmpty();
             isRightExist = !fixtureRepository.findByMonth(year, month+1).isEmpty();
         }
-
+        // 조회되는 경기 없는 경우
         if(fixtureList.isEmpty()){
             return FixtureDto.DiaryFixtureResponse.builder()
                     .soccerTeamNames(null)
@@ -153,6 +157,7 @@ public class FixtureService {
                     .isRightExist(isRightExist)
                     .build();
         }
+        // 조회된 경기 response class 형식대로 변경
         for(Fixture fixture : fixtureList){
             diaryFixtures.add(FixtureDto.DiaryFixture.builder()
                     .matchId(fixture.getId())
@@ -179,14 +184,18 @@ public class FixtureService {
     @Transactional
     public FixtureDto.DiaryFixtureResponse findDiaryFixturesByMonthAndTeam(int year, int month, String team){
         List<FixtureDto.DiaryFixture> diaryFixtures = new ArrayList<>();
+        // 가져온 경기 리스트
         List<Fixture> fixtureList = fixtureRepository.findByMonthAndTeam(year, month, team);
 
-        Boolean isLeftExist;
-        Boolean isRightExist;
+        Boolean isLeftExist; // 이전 달에 경기 존재하는지 여부
+        Boolean isRightExist; // 다음 달에 경기 존재하는지 여부
+
+        // 1월인 경우 이전 달 작년 12월로 변경해 조회
         if(month == 1){
             isLeftExist = !fixtureRepository.findByMonthAndTeam(year-1, 12, team).isEmpty();
             isRightExist = !fixtureRepository.findByMonthAndTeam(year, month+1, team).isEmpty();
         }
+        // 12월인 경우 다음 달 내년 1월로 변경해 조회
         else if(month == 12){
             isLeftExist = !fixtureRepository.findByMonthAndTeam(year, month-1, team).isEmpty();
             isRightExist = !fixtureRepository.findByMonthAndTeam(year+1, 1, team).isEmpty();
@@ -196,6 +205,7 @@ public class FixtureService {
             isRightExist = !fixtureRepository.findByMonthAndTeam(year, month+1, team).isEmpty();
         }
 
+        // 조회되는 경기 없는 경우
         if(fixtureList.isEmpty()){
             return FixtureDto.DiaryFixtureResponse.builder()
                     .soccerTeamNames(null)
@@ -204,6 +214,7 @@ public class FixtureService {
                     .isRightExist(isRightExist)
                     .build();
         }
+        // 조회된 경기 response class 형식대로 변경
         for(Fixture fixture : fixtureList){
             diaryFixtures.add(FixtureDto.DiaryFixture.builder()
                     .matchId(fixture.getId())
@@ -218,7 +229,7 @@ public class FixtureService {
                     .build());
         }
         return FixtureDto.DiaryFixtureResponse.builder()
-                .soccerTeamNames(null)
+                .soccerTeamNames(squadService.getSeasonSquads(fixtureList.get(0).getSeason()))
                 .matches(diaryFixtures)
                 .isLeftExist(isLeftExist)
                 .isRightExist(isRightExist)

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -84,6 +84,7 @@ public class SquadService {
         for(Squad squad : seasonSquads){
             squadNames.add(teamNameConvertService.convertToKrName(squad.getTeam()));
         }
+        Collections.sort(squadNames);
         return squadNames;
     }
 


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #87 
<br>
closed jira #131

## ✨ 변경 사항 및 이유
- 기록하고 싶은 경기 선택을 위한 경기 일정 조회 GET API 개발 완료
- 한달 경기 일정 조회 API 에서 시즌 팀 이름 ㄱ,ㄴ,ㄷ 정렬되도록 수정