### PR TITLE
Sf 140/feat/#99 lineup prediction api edit

### DIFF
--- a/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
+++ b/src/main/java/KickIt/server/domain/fixture/dto/FixtureDto.java
@@ -119,4 +119,26 @@ public class FixtureDto {
         }
     }
 
+    @Data
+    @Builder
+    public static class DiaryFixtureResponse{
+        private List<String> soccerTeamNames; // 해당 년도/월에 따른 프리미어리그 내의 전체 팀 이름 리스트
+        private List<DiaryFixture> matches; // 경기 리스트
+        private Boolean isLeftExist; // 왼쪽 달 경기 조회 가능 여부 (이전 달에 경기 있는지 체크)
+        private Boolean isRightExist; // 오른쪽 달 경기 조회 가능 여부 (다음 달에 경기 있는지 체크)
+    }
+
+    @Data
+    @Builder
+    public static class DiaryFixture{
+        private Long matchId; // 축구 경기 고유 ID
+        private String matchDate; // 축구 경기 날짜
+        private String matchTime; // 축구 경기 시간
+        private String homeTeamEmblemURL; // 홈팀 로고 이미지 URL
+        private String awayTeamEmblemUrl; // 원정팀 로고 이미지 URL
+        private String homeTeamName; // 홈팀 이름
+        private String awayTeamName; // 원정팀 이름
+        private Integer homeTeamScore; // 홈팀 스코어
+        private Integer awayTeamScore; // 원정팀 스코어
+    }
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -123,10 +123,6 @@ public class FixtureService {
         }
     }
 
-    public void updateFixtureStatus(Long fixtureId, int status) {
-        fixtureRepository.updateStatus(fixtureId, status);
-    }
-
     // 일기 선택을 위한 경기 일정 조회에서 사용
     // findByMonth로 가져온 해당 달의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
@@ -238,6 +234,10 @@ public class FixtureService {
                 .isLeftExist(isLeftExist)
                 .isRightExist(isRightExist)
                 .build();
+    }
+
+    public void updateFixtureStatus(Long fixtureId, int status) {
+        fixtureRepository.updateStatus(fixtureId, status);
     }
 
 }

--- a/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
+++ b/src/main/java/KickIt/server/domain/fixture/service/FixtureService.java
@@ -3,11 +3,14 @@ package KickIt.server.domain.fixture.service;
 import KickIt.server.domain.fixture.dto.FixtureDto;
 import KickIt.server.domain.fixture.entity.Fixture;
 import KickIt.server.domain.fixture.entity.FixtureRepository;
+import KickIt.server.domain.teams.service.SquadService;
+import KickIt.server.domain.teams.service.TeamNameConvertService;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -19,6 +22,10 @@ public class FixtureService {
     private FixtureRepository fixtureRepository;
     @Autowired
     private FixtureDto fixtureDto;
+    @Autowired
+    private SquadService squadService;
+    @Autowired
+    private TeamNameConvertService teamNameConvertService;
 
     // fixture List 중 중복되지 않은 fixture만을 저장
     @Transactional
@@ -68,6 +75,7 @@ public class FixtureService {
         return responseList;
     }
 
+    // 한달 경기 일정 조회 API에서 사용
     // findByMonth로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
     public FixtureDto.FixtureDateResponse findFixturesByMonth(int year, int month){
@@ -79,6 +87,7 @@ public class FixtureService {
         return response;
     }
 
+    // 한달 경기 일정 조회 API에서 사용
     // findByMonthAndTeam으로 가져온 List<Fixture>의 Fixture들 DTO의 Response 형태로 변환 후 반환
     @Transactional
     public FixtureDto.FixtureDateResponse findFixtureByMonthAndTeam(int year, int month, String team){
@@ -116,6 +125,119 @@ public class FixtureService {
 
     public void updateFixtureStatus(Long fixtureId, int status) {
         fixtureRepository.updateStatus(fixtureId, status);
+    }
+
+    // 일기 선택을 위한 경기 일정 조회에서 사용
+    // findByMonth로 가져온 해당 달의 Fixture들 DTO의 Response 형태로 변환 후 반환
+    @Transactional
+    public FixtureDto.DiaryFixtureResponse findDiaryFixturesByMonth(int year, int month){
+        List<FixtureDto.DiaryFixture> diaryFixtures = new ArrayList<>();
+        // 가져온 경기 리스트
+        List<Fixture> fixtureList = fixtureRepository.findByMonth(year, month);
+
+        Boolean isLeftExist; // 이전 달에 경기 존재하는지 여부
+        Boolean isRightExist; // 다음 달에 경기 존재하는지 여부
+
+        // 1월인 경우 이전 달 작년 12월로 변경해 조회
+        if(month == 1){
+            isLeftExist = !fixtureRepository.findByMonth(year-1, 12).isEmpty();
+            isRightExist = !fixtureRepository.findByMonth(year, month+1).isEmpty();
+        }
+        // 12월인 경우 다음 달 내년 1월로 변경해 조회
+        else if(month == 12){
+            isLeftExist = !fixtureRepository.findByMonth(year, month-1).isEmpty();
+            isRightExist = !fixtureRepository.findByMonth(year+1, 1).isEmpty();
+        }
+        else{
+            isLeftExist = !fixtureRepository.findByMonth(year, month-1).isEmpty();
+            isRightExist = !fixtureRepository.findByMonth(year, month+1).isEmpty();
+        }
+        // 조회되는 경기 없는 경우
+        if(fixtureList.isEmpty()){
+            return FixtureDto.DiaryFixtureResponse.builder()
+                    .soccerTeamNames(null)
+                    .matches(null)
+                    .isLeftExist(isLeftExist)
+                    .isRightExist(isRightExist)
+                    .build();
+        }
+        // 조회된 경기 response class 형식대로 변경
+        for(Fixture fixture : fixtureList){
+            diaryFixtures.add(FixtureDto.DiaryFixture.builder()
+                    .matchId(fixture.getId())
+                    .matchDate(new SimpleDateFormat("yyyy-MM-dd").format(fixture.getDate()))
+                    .matchTime(new SimpleDateFormat("HH:mm").format(fixture.getDate()))
+                    .homeTeamEmblemURL(squadService.getTeamLogoImg(fixture.getSeason(), fixture.getHomeTeam()))
+                    .awayTeamEmblemUrl(squadService.getTeamLogoImg(fixture.getSeason(), fixture.getAwayTeam()))
+                    .homeTeamName(teamNameConvertService.convertToKrName(fixture.getHomeTeam()))
+                    .awayTeamName(teamNameConvertService.convertToKrName(fixture.getAwayTeam()))
+                    .homeTeamScore(fixture.getHomeTeamScore())
+                    .awayTeamScore(fixture.getAwayteamScore())
+                    .build());
+        }
+        return FixtureDto.DiaryFixtureResponse.builder()
+                .soccerTeamNames(squadService.getSeasonSquads(fixtureList.get(0).getSeason()))
+                .matches(diaryFixtures)
+                .isLeftExist(isLeftExist)
+                .isRightExist(isRightExist)
+                .build();
+    }
+
+    // 일기 선택을 위한 경기 일정 조회에서 사용
+    // findByMonthAndTeam으로 가져온 해당 달의 Fixture들 DTO의 Response 형태로 변환 후 반환
+    @Transactional
+    public FixtureDto.DiaryFixtureResponse findDiaryFixturesByMonthAndTeam(int year, int month, String team){
+        List<FixtureDto.DiaryFixture> diaryFixtures = new ArrayList<>();
+        // 가져온 경기 리스트
+        List<Fixture> fixtureList = fixtureRepository.findByMonthAndTeam(year, month, team);
+
+        Boolean isLeftExist; // 이전 달에 경기 존재하는지 여부
+        Boolean isRightExist; // 다음 달에 경기 존재하는지 여부
+
+        // 1월인 경우 이전 달 작년 12월로 변경해 조회
+        if(month == 1){
+            isLeftExist = !fixtureRepository.findByMonthAndTeam(year-1, 12, team).isEmpty();
+            isRightExist = !fixtureRepository.findByMonthAndTeam(year, month+1, team).isEmpty();
+        }
+        // 12월인 경우 다음 달 내년 1월로 변경해 조회
+        else if(month == 12){
+            isLeftExist = !fixtureRepository.findByMonthAndTeam(year, month-1, team).isEmpty();
+            isRightExist = !fixtureRepository.findByMonthAndTeam(year+1, 1, team).isEmpty();
+        }
+        else{
+            isLeftExist = !fixtureRepository.findByMonthAndTeam(year, month-1, team).isEmpty();
+            isRightExist = !fixtureRepository.findByMonthAndTeam(year, month+1, team).isEmpty();
+        }
+
+        // 조회되는 경기 없는 경우
+        if(fixtureList.isEmpty()){
+            return FixtureDto.DiaryFixtureResponse.builder()
+                    .soccerTeamNames(null)
+                    .matches(null)
+                    .isLeftExist(isLeftExist)
+                    .isRightExist(isRightExist)
+                    .build();
+        }
+        // 조회된 경기 response class 형식대로 변경
+        for(Fixture fixture : fixtureList){
+            diaryFixtures.add(FixtureDto.DiaryFixture.builder()
+                    .matchId(fixture.getId())
+                    .matchDate(new SimpleDateFormat("yyyy-MM-dd").format(fixture.getDate()))
+                    .matchTime(new SimpleDateFormat("HH:mm").format(fixture.getDate()))
+                    .homeTeamEmblemURL(squadService.getTeamLogoImg(fixture.getSeason(), fixture.getHomeTeam()))
+                    .awayTeamEmblemUrl(squadService.getTeamLogoImg(fixture.getSeason(), fixture.getAwayTeam()))
+                    .homeTeamName(teamNameConvertService.convertToKrName(fixture.getHomeTeam()))
+                    .awayTeamName(teamNameConvertService.convertToKrName(fixture.getAwayTeam()))
+                    .homeTeamScore(fixture.getHomeTeamScore())
+                    .awayTeamScore(fixture.getAwayteamScore())
+                    .build());
+        }
+        return FixtureDto.DiaryFixtureResponse.builder()
+                .soccerTeamNames(squadService.getSeasonSquads(fixtureList.get(0).getSeason()))
+                .matches(diaryFixtures)
+                .isLeftExist(isLeftExist)
+                .isRightExist(isRightExist)
+                .build();
     }
 
 }

--- a/src/main/java/KickIt/server/domain/lineup/dto/MatchLineupDto.java
+++ b/src/main/java/KickIt/server/domain/lineup/dto/MatchLineupDto.java
@@ -101,7 +101,7 @@ public class MatchLineupDto {
     }
 
     @Getter
-    public class MatchPosPlayersDto{
+    public static class MatchPosPlayersDto{
         private List<ResponsePlayerInfo> goalkeeper;
         private List<ResponsePlayerInfo> defenders;
         private List<ResponsePlayerInfo> midfielders;
@@ -122,6 +122,14 @@ public class MatchLineupDto {
                 midfielders = players.get(2);
                 strikers = players.get(3);
             }
+        }
+
+        public MatchPosPlayersDto(List<ResponsePlayerInfo> goalkeeper, List<ResponsePlayerInfo> defenders, List<ResponsePlayerInfo> midfielders, List<ResponsePlayerInfo> secondMidFielders, List<ResponsePlayerInfo> strikers) {
+            this.goalkeeper = goalkeeper;
+            this.defenders = defenders;
+            this.midfielders = midfielders;
+            this.secondMidFielders = secondMidFielders;
+            this.strikers = strikers;
         }
     }
 }

--- a/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/controller/LineupPredictionController.java
@@ -296,13 +296,6 @@ public class LineupPredictionController {
                 String season = foundFixture.get().getSeason();
                 LineupPredictionDto.LineupInquireResponse response = lineupPredictionService.inquireLineupPrediction(matchId, member.getId(), homeTeam, awayTeam, season);
 
-                // 사용자 id와 경기 id로 조회된 선발 라인업 예측 데이터 없음
-                if(response == null){
-                    responseBody.put("status", HttpStatus.NOT_FOUND.value());
-                    responseBody.put("message", "해당 사용자의 선발 라인업 예측 데이터 없음");
-                    responseBody.put("isSuccess", false);
-                    return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
-                }
                 // 정상적으로 가져온 response data에 넣어 반환
                 responseBody.put("status", HttpStatus.OK.value());
                 responseBody.put("message", "success");

--- a/src/main/java/KickIt/server/domain/lineupPrediction/dto/LineupPredictionDto.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/dto/LineupPredictionDto.java
@@ -1,6 +1,7 @@
 package KickIt.server.domain.lineupPrediction.dto;
 
 import KickIt.server.domain.fixture.dto.ResponsePlayerInfo;
+import KickIt.server.domain.lineup.dto.MatchLineupDto;
 import KickIt.server.domain.member.entity.Member;
 import KickIt.server.domain.teams.PlayerPosition;
 import KickIt.server.domain.teams.entity.Player;
@@ -163,9 +164,9 @@ public class LineupPredictionDto {
         private int participant;
 
         private String homeFormation;
-        private ResponseLineup homeLineups;
+        private MatchLineupDto.MatchPosPlayersDto homeLineups;
         private String awayFormation;
-        private ResponseLineup awayLineups;
+        private MatchLineupDto.MatchPosPlayersDto awayLineups;
 
         private int userHomeFormation;
         private ResponseLineup userHomePrediction;

--- a/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
@@ -405,6 +405,8 @@ public class LineupPredictionService {
 
                 response = LineupPredictionDto.LineupResultInquireResponse.builder()
                         .participant(lineupPredictionRepository.findByFixture(fixtureId).size())
+                        .homeFormation(foundMatchLineup.getHomeFormation())
+                        .awayFormation(foundMatchLineup.getAwayFormation())
                         .homeLineups(foundHomeLineup)
                         .awayLineups(foundAwayLineup)
                         .build();

--- a/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
@@ -318,14 +318,6 @@ public class LineupPredictionService {
     public LineupPredictionDto.LineupInquireResponse inquireLineupPrediction(Long fixtureId, Long memberId, String homeTeam, String awayTeam, String season){
         LineupPrediction lineupPrediction = lineupPredictionRepository.findByMemberAndFixture(memberId, fixtureId).orElse(null);
 
-        // memberId와 fixtureId로 조회한 선발 라인업 예측 data 존재하지 않는 경우
-        // null 반환 후 이후 controller 상에서 예외 처리
-        if(lineupPrediction == null){
-            return null;
-        }
-
-        // memberId와 fixtureId로 조회한 선발 라인업 예측 data 존재하는 경우
-
         // 시즌, 팀으로 찾아온 홈팀 / 원정팀 전체 선수 명단
         List<Player> homePlayers = squadRepository.findBySeasonAndTeam(season, homeTeam).get().getPlayers();
         List<Player> awayPlayers = squadRepository.findBySeasonAndTeam(season, awayTeam).get().getPlayers();
@@ -341,6 +333,16 @@ public class LineupPredictionService {
             awayPlayerInfos.add(new LineupPredictionDto.ResponsePlayerInfo2(player));
         }
 
+        // memberId와 fixtureId로 조회한 선발 라인업 예측 data 존재하지 않는 경우
+        if(lineupPrediction == null){
+            LineupPredictionDto.LineupInquireResponse response = LineupPredictionDto.LineupInquireResponse.builder()
+                    .homePlayers(homePlayerInfos)
+                    .awayPlayers(awayPlayerInfos)
+                    .build();
+            return response;
+        }
+
+        // memberId와 fixtureId로 조회한 선발 라인업 예측 data 존재하는 경우
         // 사용자가 예측한 기존 홈팀 선발 라인업 정보
         LineupPredictionDto.InquiredLineupPrediction homeLineup = LineupPredictionDto.InquiredLineupPrediction.builder()
                 .formation(lineupPrediction.getHomeTeamForm())

--- a/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
+++ b/src/main/java/KickIt/server/domain/lineupPrediction/service/LineupPredictionService.java
@@ -396,19 +396,11 @@ public class LineupPredictionService {
             }
             else{
                 // 실제 홈팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundHomeLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getHomeLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getHomeLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getHomeLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getHomeLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundHomeLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getHomeLineups().getGoalkeeper(), foundMatchLineup.getHomeLineups().getDefenders(), foundMatchLineup.getHomeLineups().getMidfielders(), foundMatchLineup.getHomeLineups().getSecondMidFielders(), foundMatchLineup.getHomeLineups().getStrikers());
+
                 // 실제 원정팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundAwayLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getAwayLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getAwayLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getAwayLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getAwayLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundAwayLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getAwayLineups().getGoalkeeper(), foundMatchLineup.getAwayLineups().getDefenders(), foundMatchLineup.getAwayLineups().getMidfielders(),foundMatchLineup.getAwayLineups().getSecondMidFielders(), foundMatchLineup.getAwayLineups().getStrikers());
+
                 response = LineupPredictionDto.LineupResultInquireResponse.builder()
                         .participant(lineupPredictionRepository.findByFixture(fixtureId).size())
                         .homeLineups(foundHomeLineup)
@@ -434,19 +426,10 @@ public class LineupPredictionService {
             // 사용자 예측 X / 선발 라인업 결과 O
             else{
                 // 실제 홈팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundHomeLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getHomeLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getHomeLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getHomeLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getHomeLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundHomeLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getHomeLineups().getGoalkeeper(), foundMatchLineup.getHomeLineups().getDefenders(), foundMatchLineup.getHomeLineups().getMidfielders(), foundMatchLineup.getHomeLineups().getSecondMidFielders(), foundMatchLineup.getHomeLineups().getStrikers());
+
                 // 실제 원정팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundAwayLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getAwayLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getAwayLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getAwayLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getAwayLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundAwayLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getAwayLineups().getGoalkeeper(), foundMatchLineup.getAwayLineups().getDefenders(), foundMatchLineup.getAwayLineups().getMidfielders(),foundMatchLineup.getAwayLineups().getSecondMidFielders(), foundMatchLineup.getAwayLineups().getStrikers());
 
                 response = LineupPredictionDto.LineupResultInquireResponse.builder()
                         .participant(lineupPredictionRepository.findByFixture(fixtureId).size())
@@ -494,19 +477,10 @@ public class LineupPredictionService {
             // 사용자 예측 O / 선발 라인업 결과 O
             else{
                 // 실제 홈팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundHomeLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getHomeLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getHomeLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getHomeLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getHomeLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundHomeLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getHomeLineups().getGoalkeeper(), foundMatchLineup.getHomeLineups().getDefenders(), foundMatchLineup.getHomeLineups().getMidfielders(), foundMatchLineup.getHomeLineups().getSecondMidFielders(), foundMatchLineup.getHomeLineups().getStrikers());
+
                 // 실제 원정팀 선발라인업 정보 필요한 형식의 클래스 객체로 만들어 줌
-                LineupPredictionDto.ResponseLineup foundAwayLineup = LineupPredictionDto.ResponseLineup.builder()
-                        .goalkeeper(foundMatchLineup.getAwayLineups().getGoalkeeper().get(0))
-                        .defenders(foundMatchLineup.getAwayLineups().getDefenders())
-                        .midfielders(foundMatchLineup.getAwayLineups().getMidfielders())
-                        .strikers(foundMatchLineup.getAwayLineups().getStrikers())
-                        .build();
+                MatchLineupDto.MatchPosPlayersDto foundAwayLineup = new MatchLineupDto.MatchPosPlayersDto(foundMatchLineup.getAwayLineups().getGoalkeeper(), foundMatchLineup.getAwayLineups().getDefenders(), foundMatchLineup.getAwayLineups().getMidfielders(),foundMatchLineup.getAwayLineups().getSecondMidFielders(), foundMatchLineup.getAwayLineups().getStrikers());
 
                 response = LineupPredictionDto.LineupResultInquireResponse.builder()
                         .participant(lineupPredictionRepository.findByFixture(fixtureId).size())

--- a/src/main/java/KickIt/server/domain/matchPrediction/dto/MatchPredictionDto.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/dto/MatchPredictionDto.java
@@ -27,7 +27,7 @@ public class MatchPredictionDto {
         int homeFormation; // 홈팀의 1순위 예상 포메이션
         int awayFormation; // 원정팀의 1순위 예상 포메이션
         Boolean isParticipated; // 사용자가 우승팀 예측을 했는지 여부
-        int participant; // 예측에 참여한 사람의 수 -> 예측 종료 시에만 전송 -> 예측 종료 시에만 전송
+        int participant; // 예측에 참여한 사람의 수
         Boolean isPredictionSuccessful; // 사용자가 예측을 성공했는지 여부 -> 예측 종료 시에만 전송
     }
 
@@ -39,7 +39,7 @@ public class MatchPredictionDto {
     public static class InquiredScorePrediction{
         int homePercentage; // 홈팀의 예측 우승 확률(백분율)
         Boolean isParticipated; // 사용자가 우승팀 예측을 했는지 여부
-        int participant; // 예측에 참여한 사람의 수 -> 예측 종료 시에만 전송
-        Boolean isPredictionSuccessful; // 사용자가 예측 성공했는지 여부
+        int participant; // 예측에 참여한 사람의 수
+        Boolean isPredictionSuccessful; // 사용자가 예측 성공했는지 여부 -> 예측 종료 시에만 전송
     }
 }

--- a/src/main/java/KickIt/server/domain/matchPrediction/service/MatchPredictionService.java
+++ b/src/main/java/KickIt/server/domain/matchPrediction/service/MatchPredictionService.java
@@ -49,7 +49,7 @@ public class MatchPredictionService {
         // 우승팀 예측 참여 사용자
         int scoreParticipant = scorePredictionRepository.findByFixture(fixture.getId()).size();
 
-        // 우승팀 예측 종료 전인 경우 (경기 시작 전) -> participant, isPredictionSuccessful 전송 X
+        // 우승팀 예측 종료 전인 경우 (경기 시작 전) -> isPredictionSuccessful 전송 X
         if(ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")).isBefore(ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul")))){
             // 테스트 코드
             Logger.getGlobal().log(Level.INFO, String.format("우승팀 예측 종료 전: 현재 시간: %s, 경기 시간: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul"))));
@@ -58,6 +58,7 @@ public class MatchPredictionService {
                 scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
                         .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
                         .isParticipated(false)
+                        .participant(scoreParticipant)
                         .build();
             }
             // 사용자가 기존에 우승팀 예측 진행한 경우
@@ -65,10 +66,11 @@ public class MatchPredictionService {
                 scorePrediction = MatchPredictionDto.InquiredScorePrediction.builder()
                         .homePercentage(figureHomeWinningPercent(fixture.getId(), scoreParticipant))
                         .isParticipated(true)
+                        .participant(scoreParticipant)
                         .build();
             }
         }
-        // 우승팀 예측 종료된 경우 (경기 시작 후) -> participant, isPredictionSuccessful 포함
+        // 우승팀 예측 종료된 경우 (경기 시작 후) -> isPredictionSuccessful 포함
         else{
             // 테스트 코드
             Logger.getGlobal().log(Level.INFO, String.format("우승팀 예측 종료 후: 현재 시간: %s, 경기 시간: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant(), ZoneId.of("Asia/Seoul"))));
@@ -113,7 +115,7 @@ public class MatchPredictionService {
         Integer homeFormation = lineupPredictionRepository.findAvgHomeTeamForm(fixture.getId());
         Integer awayFormation = lineupPredictionRepository.findAvgAwayTeamForm(fixture.getId());
 
-        // 선발라인업 예측 종료 전인 경우 (경기 시작 1시간 30분 전) -> participant, isPredictionSuccessful 전송 X
+        // 선발라인업 예측 종료 전인 경우 (경기 시작 1시간 30분 전) -> isPredictionSuccessful 전송 X
         if(ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")).isBefore(ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul")))){
             // 테스트 코드
             Logger.getGlobal().log(Level.INFO, String.format("선발라인업 예측 종료 전: 현재 시간: %s, 경기 시간 90분 전: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul"))));
@@ -121,6 +123,7 @@ public class MatchPredictionService {
             if(lineupParticipant == 0){
                 lineupPrediction = MatchPredictionDto.InquiredLineupPrediction.builder()
                         .isParticipated(false)
+                        .participant(lineupParticipant)
                         .build();
             }
             // 사용자가 기존에 선발라인업 예측 진행하지 않은 경우
@@ -130,6 +133,7 @@ public class MatchPredictionService {
                         .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
                         .homeFormation(homeFormation)
                         .awayFormation(awayFormation)
+                        .participant(lineupParticipant)
                         .isParticipated(false)
                         .build();
             }
@@ -140,11 +144,12 @@ public class MatchPredictionService {
                         .awayPercentage(figureFormationPercent(fixture.getId(), lineupParticipant, awayFormation, false))
                         .homeFormation(homeFormation)
                         .awayFormation(awayFormation)
+                        .participant(lineupParticipant)
                         .isParticipated(true)
                         .build();
             }
         }
-        // 선발라인업 예측 종료 후인 경우 (경기 시작 1시간 30분 전 후) -> participant, isPredictionSuccessful 전송
+        // 선발라인업 예측 종료 후인 경우 (경기 시작 1시간 30분 전 후) -> isPredictionSuccessful 전송
         else{
             // 테스트 코드
             Logger.getGlobal().log(Level.INFO, String.format("선발라인업 예측 종료 후: 현재 시간: %s, 경기 시간 90분 전: %s", ZonedDateTime.ofInstant(LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul")), ZonedDateTime.ofInstant(fixture.getDate().toInstant().minus(1, ChronoUnit.HOURS).minus(30, ChronoUnit.MINUTES), ZoneId.of("Asia/Seoul"))));

--- a/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
+++ b/src/main/java/KickIt/server/domain/teams/controller/SquadController.java
@@ -50,39 +50,12 @@ public class SquadController {
 
     @GetMapping("name-url")
     // 현재 시즌 프리미어리그 팀 전체의 이름과 로고 이미지 조회 API
-    public ResponseEntity<Map<String, Object>> inquireEplTeamNameAndUrl(){
+    public ResponseEntity<Map<String, Object>> inquireEplTeamNameAndUrl(@RequestHeader(value = "xAuthToken", required = false) String xAuthToken){
         // 반환할 response
         Map<String, Object> responseBody = new HashMap<>();
-        List<SquadDto.EplNameUrlResponse> data = squadService.getEplTeamNameAndUrl();
-        // 등록된 것 중 가장 최근 시즌의 Squad 데이터 조회 완료
-        if(data != null){
-            responseBody.put("status", HttpStatus.OK.value());
-            responseBody.put("message", "success");
-            responseBody.put("data", data);
-            responseBody.put("isSuccess", true);
-            return new ResponseEntity<>(responseBody, HttpStatus.OK);
-        }
-        // 조회한 squad 데이터가 없는 경우
-        else{
-            responseBody.put("status", HttpStatus.NOT_FOUND.value());
-            responseBody.put("message", "현재 시즌 팀 데이터 조회 실패");
-            responseBody.put("isSuccess", false);
-            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
-        }
-    }
 
-    @GetMapping("name-url/withAuth")
-    // 현재 시즌 프리미어리그 팀 전체의 이름과 로고 이미지 조회 API (xAuthToken 있음)
-    public ResponseEntity<Map<String, Object>> inquireEplTeamNameAndUrl(@RequestHeader(value = "xAuthToken") String xAuthToken){
-        // 반환할 response
-        Map<String, Object> responseBody = new HashMap<>();
-        // member를 찾기 위해 token으로 email 조회
-        String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
-        // 찾은 email로 member 조회
-        Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
-
-        // 입력된 token의 email로 찾은 member가 존재하는 경우
-        if(foundMember != null){
+        // xAuthToken 없는 경우
+        if(xAuthToken == null){
             List<SquadDto.EplNameUrlResponse> data = squadService.getEplTeamNameAndUrl();
             // 등록된 것 중 가장 최근 시즌의 Squad 데이터 조회 완료
             if(data != null){
@@ -100,12 +73,40 @@ public class SquadController {
                 return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
             }
         }
-        // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+
+        // xAuthToken 있는 경우
         else{
-            responseBody.put("status", HttpStatus.NOT_FOUND.value());
-            responseBody.put("message", "해당 사용자 없음");
-            responseBody.put("isSuccess", false);
-            return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            // member를 찾기 위해 token으로 email 조회
+            String memberEmail = jwtTokenUtil.getEmailFromToken(xAuthToken);
+            // 찾은 email로 member 조회
+            Member foundMember = memberRepository.findByEmailAndAuthProvider(memberEmail, memberService.transAuth("kakao")).orElse(null);
+
+            // 입력된 token의 email로 찾은 member가 존재하는 경우
+            if(foundMember != null){
+                List<SquadDto.EplNameUrlResponse> data = squadService.getEplTeamNameAndUrl();
+                // 등록된 것 중 가장 최근 시즌의 Squad 데이터 조회 완료
+                if(data != null){
+                    responseBody.put("status", HttpStatus.OK.value());
+                    responseBody.put("message", "success");
+                    responseBody.put("data", data);
+                    responseBody.put("isSuccess", true);
+                    return new ResponseEntity<>(responseBody, HttpStatus.OK);
+                }
+                // 조회한 squad 데이터가 없는 경우
+                else{
+                    responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                    responseBody.put("message", "현재 시즌 팀 데이터 조회 실패");
+                    responseBody.put("isSuccess", false);
+                    return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+                }
+            }
+            // 입력된 token의 email로 찾은 member가 존재하지 않는 경우
+            else{
+                responseBody.put("status", HttpStatus.NOT_FOUND.value());
+                responseBody.put("message", "해당 사용자 없음");
+                responseBody.put("isSuccess", false);
+                return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+            }
         }
     }
 }

--- a/src/main/java/KickIt/server/domain/teams/service/SquadService.java
+++ b/src/main/java/KickIt/server/domain/teams/service/SquadService.java
@@ -84,6 +84,7 @@ public class SquadService {
         for(Squad squad : seasonSquads){
             squadNames.add(teamNameConvertService.convertToKrName(squad.getTeam()));
         }
+        Collections.sort(squadNames);
         return squadNames;
     }
 


### PR DESCRIPTION
## 🎟️ 관련 이슈 번호, Jira 번호
closed issue #99
<br>
closed jira #140

## ✨ 변경 사항 및 이유
- 선발라인업 예측 결과 API F/E 요청 사항대로 수정 완료.
- homeFormation, awayFormation String으로 변경
-  homeLineups랑 awayLineups에 secondMidfielders 추가 
- 프리미어리그 시즌 팀 이름, URL 조회 API xAuthToken 유무 따라 분리했던 API 하나로 통합
- 선발라인업 예측 조회 API에서 기존에 예측 진행하지 않았어도 조회 가능하게 수정 
